### PR TITLE
Modularize DeepResearch docs

### DIFF
--- a/DeepResearch/README.md
+++ b/DeepResearch/README.md
@@ -1,0 +1,10 @@
+# Deep Research Documentation
+
+This folder contains research and design documents for developing portfolio management and trading bots.
+
+## Contents
+
+- [AlgoTradingV1](AlgoTradingV1.md)
+- [Bot Portfolio Manager Design](Bot-PortfolioManager-DeepResearch)
+- [Deep Research Algo Trading Notes](DeepResearch_AlgoTrading)
+- [Modular Sections](sections/README.md)

--- a/DeepResearch/sections/README.md
+++ b/DeepResearch/sections/README.md
@@ -1,0 +1,9 @@
+# Deep Research Sections
+
+This directory contains the modular documentation split from `DeepResearch_AlgoTrading`.
+
+- [Risk Management](risk_management.md)
+- [Quantitative Methods](quantitative_methods.md)
+- [Backtesting & Validation](backtesting_validation.md)
+- [Trading Bot Implementation](trading_bot_implementation.md)
+- [Additional Notes](additional_notes.md)

--- a/DeepResearch/sections/additional_notes.md
+++ b/DeepResearch/sections/additional_notes.md
@@ -1,0 +1,167 @@
+I'll now conduct research and compile practical insights for each section, including Python-based implementation.
+
+Developing a robust, risk-aware algorithmic trading strategy involves integrating effective risk management techniques with quantitative methods for high-probability trade selection. This guide provides practical insights and Python-based examples tailored for retail algorithmic traders, focusing on equities and options within swing and mid-term trading horizons.
+1. Risk Management in Algorithmic Trading
+
+Capital Preservation & Position Sizing
+
+    Kelly Criterion: This formula helps determine the optimal fraction of capital to allocate per trade based on expected win probability and payoff ratio.
+
+  def kelly_criterion(win_prob, win_loss_ratio):
+      return win_prob - (1 - win_prob) / win_loss_ratio
+
+  # Example usage
+  win_probability = 0.55  # 55% win rate
+  win_loss_ratio = 1.5    # Average win is 1.5 times the average loss
+  optimal_fraction = kelly_criterion(win_probability, win_loss_ratio)
+  print(f"Optimal capital allocation per trade: {optimal_fraction:.2%}")
+
+    Volatility-Based Position Sizing: Adjust position sizes based on market volatility, using indicators like Average True Range (ATR) to determine stop-loss distances.
+
+  import pandas as pd
+
+  def calculate_atr(data, period=14):
+      data['H-L'] = data['High'] - data['Low']
+      data['H-PC'] = abs(data['High'] - data['Close'].shift(1))
+      data['L-PC'] = abs(data['Low'] - data['Close'].shift(1))
+      tr = data[['H-L', 'H-PC', 'L-PC']].max(axis=1)
+      atr = tr.rolling(window=period).mean()
+      return atr
+
+  # Example usage with a DataFrame 'df' containing 'High', 'Low', 'Close' columns
+  df['ATR'] = calculate_atr(df)
+
+Managing Drawdowns & Risk-Adjusted Returns
+
+    Maximum Drawdown (MDD): Measure the largest peak-to-trough decline in your portfolio to assess risk.
+
+  def max_drawdown(returns):
+      cumulative = (1 + returns).cumprod()
+      peak = cumulative.cummax()
+      drawdown = (cumulative - peak) / peak
+      return drawdown.min()
+
+  # Example usage with a pandas Series 'returns'
+  mdd = max_drawdown(returns)
+  print(f"Maximum Drawdown: {mdd:.2%}")
+
+    Sharpe Ratio: Evaluate risk-adjusted returns by comparing the portfolio return to the risk-free rate, adjusted for volatility.
+
+  def sharpe_ratio(returns, risk_free_rate=0.01):
+      excess_returns = returns - risk_free_rate / 252
+      return excess_returns.mean() / returns.std() * (252 ** 0.5)
+
+  # Example usage with daily returns
+  sharpe = sharpe_ratio(returns)
+  print(f"Sharpe Ratio: {sharpe:.2f}")
+
+Modern Risk Control Techniques
+
+    Volatility Targeting: Adjust exposure to maintain consistent portfolio volatility, scaling positions inversely with market volatility.
+
+  target_volatility = 0.02  # Target daily volatility (e.g., 2%)
+  current_volatility = returns.std()
+  scaling_factor = target_volatility / current_volatility
+  adjusted_positions = original_positions * scaling_factor
+
+    Beta Hedging: Mitigate market risk by hedging positions based on their beta, aligning portfolio beta to a desired level.
+
+  portfolio_beta = sum(position['beta'] * position['value'] for position in portfolio) / total_portfolio_value
+  desired_beta = 1.0  # Neutral market exposure
+  hedge_ratio = (portfolio_beta - desired_beta) / market_beta
+
+2. Quantitative Methods for High-Probability Trade Selection
+
+Probability-Based Models
+
+    Expected Value (EV): Calculate the anticipated value of a trade by weighing potential outcomes by their probabilities.
+
+  def expected_value(win_prob, avg_win, avg_loss):
+      loss_prob = 1 - win_prob
+      return (win_prob * avg_win) - (loss_prob * avg_loss)
+
+  # Example usage
+  ev = expected_value(win_probability, average_win, average_loss)
+  print(f"Expected Value per trade: ${ev:.2f}")
+
+    Bayesian Inference: Update the probability of a trading signal's success as new data becomes available.
+
+  from scipy.stats import beta
+
+  # Prior parameters
+  alpha_prior = 1
+  beta_prior = 1
+
+  # Observed wins and losses
+  wins = 55
+  losses = 45
+
+  # Posterior distribution
+  alpha_post = alpha_prior + wins
+  beta_post = beta_prior + losses
+  posterior = beta(alpha_post, beta_post)
+
+  # Updated probability of success
+  updated_prob = posterior.mean()
+  print(f"Updated win probability: {updated_prob:.2%}")
+
+Statistical & Alternative Indicators
+
+    Z-Score for Mean Reversion: Identify overbought or oversold conditions by measuring how many standard deviations the price is from the mean.
+
+  def z_score(series):
+      return (series - series.mean()) / series.std()
+
+  # Example usage
+  df['Z-Score'] = z_score(df['Close'])
+
+    Alternative Data Analysis: Incorporate non-traditional data sources, such as sentiment analysis from social media or macroeconomic indicators, to enhance trading signals.
+
+  from textblob import TextBlob
+
+  def sentiment_analysis(text):
+      return TextBlob(text).sentiment.polarity
+
+  # Example usage with a DataFrame 'news_df' containing 'headline' column
+  news_df['Sentiment'] = news_df['headline'].apply(sentiment_analysis)
+
+Machine Learning for Trade Selection
+
+    Interpretable Models: Utilize models like Random Forests to predict trade outcomes, ensuring the ability to interpret feature importance.
+
+  from sklearn.ensemble import RandomForestClassifier
+ 
+::contentReference[oaicite:0]{index=0}
+ 
+
+You said:
+Thats all? That wasnt exactly comprehensive
+ChatGPT said:
+
+You're right—it was more of a structured outline with some initial implementation examples. I'll now expand on each section with deeper research, providing more in-depth analysis, additional practical strategies, and fully developed Python examples for direct implementation.
+
+I'll start by covering:
+
+    Risk Management in Algorithmic Trading
+        More comprehensive position sizing models with examples
+        Advanced risk control techniques beyond stop-loss
+        Real-world examples of risk-adjusted performance metrics
+
+    Quantitative Methods for High-Probability Trade Selection
+        More robust statistical approaches, including Bayesian models
+        A deep dive into time-series models and their applications
+        More details on alternative data and its impact on trade selection
+
+    Backtesting & Validation of Risk Models
+        Common backtesting errors and solutions
+        Implementation of stress-testing strategies
+        How professional quants validate risk models before deployment
+
+    Implementation in a Trading Bot (Alpaca API)
+        Real-world risk mitigation strategies for automated trading
+        Dynamic risk adjustments in real-time using API calls
+        Advanced execution strategies to avoid market anomalies
+
+I'll conduct deeper research and expand on each of these areas with practical implementation guidance.
+
+Apologies for the earlier brevity. Let's delve deeper into advanced risk management techniques and statistical methods for identifying high-probability trades in algorithmic trading, with a focus on practical implementation using Python and the Alpaca API.

--- a/DeepResearch/sections/backtesting_validation.md
+++ b/DeepResearch/sections/backtesting_validation.md
@@ -1,0 +1,16 @@
+3. Backtesting & Validation of Risk Models
+
+    Robust Backtesting Techniques
+        Walk-forward analysis for live trading simulation.
+        Stationarity tests and autocorrelation analysis to avoid spurious results.
+        Defining realistic execution assumptions (slippage, spreads, order latency).
+
+    Stress-Testing Risk Models
+        Market shock simulations (historical scenarios, VaR analysis).
+        Parameter sensitivity analysis to detect overfitting.
+        Handling missing or unreliable data in backtesting.
+
+    Avoiding Backtesting Pitfalls
+        Lookahead bias and data snooping issues.
+        Survivorship bias in equities datasets.
+        Overfitting detection using cross-validation techniques.

--- a/DeepResearch/sections/quantitative_methods.md
+++ b/DeepResearch/sections/quantitative_methods.md
@@ -1,0 +1,119 @@
+2. Quantitative Methods for High-Probability Trade Selection
+
+    Probability-Based Models
+        Expected value (EV) framework for systematic trade selection.
+        Bayesian inference for updating trade probabilities based on new market data.
+        Z-score trading and mean reversion strategies.
+
+    Statistical & Alternative Indicators
+        Factor-based models (momentum, volatility, seasonality).
+        Alternative data (sentiment analysis, options flow, macroeconomic factors).
+        Feature engineering with time-series analysis (ARIMA, GARCH).
+
+    Machine Learning for Trade Selection
+        Interpretable ML models (XGBoost, Random Forests) for probability estimation.
+        Bayesian optimization for strategy refinement.
+        Ensemble methods to reduce overfitting in signal generation.
+
+
+2. Quantitative Methods for High-Probability Trade Selection
+
+Probability-Based Models
+
+    Expected Value (EV): Calculate the anticipated value of a trade by weighing potential outcomes by their probabilities.
+
+  def expected_value(win_prob, avg_win, avg_loss):
+      loss_prob = 1 - win_prob
+      return (win_prob * avg_win) - (loss_prob * avg_loss)
+
+  # Example usage
+  ev = expected_value(win_probability, average_win, average_loss)
+  print(f"Expected Value per trade: ${ev:.2f}")
+
+    Bayesian Inference: Update the probability of a trading signal's success as new data becomes available.
+
+  from scipy.stats import beta
+
+  # Prior parameters
+  alpha_prior = 1
+  beta_prior = 1
+
+  # Observed wins and losses
+  wins = 55
+  losses = 45
+
+  # Posterior distribution
+  alpha_post = alpha_prior + wins
+  beta_post = beta_prior + losses
+  posterior = beta(alpha_post, beta_post)
+
+  # Updated probability of success
+  updated_prob = posterior.mean()
+  print(f"Updated win probability: {updated_prob:.2%}")
+
+Statistical & Alternative Indicators
+
+    Z-Score for Mean Reversion: Identify overbought or oversold conditions by measuring how many standard deviations the price is from the mean.
+
+  def z_score(series):
+      return (series - series.mean()) / series.std()
+
+  # Example usage
+  df['Z-Score'] = z_score(df['Close'])
+
+    Alternative Data Analysis: Incorporate non-traditional data sources, such as sentiment analysis from social media or macroeconomic indicators, to enhance trading signals.
+
+  from textblob import TextBlob
+
+  def sentiment_analysis(text):
+      return TextBlob(text).sentiment.polarity
+
+  # Example usage with a DataFrame 'news_df' containing 'headline' column
+  news_df['Sentiment'] = news_df['headline'].apply(sentiment_analysis)
+
+Machine Learning for Trade Selection
+
+    Interpretable Models: Utilize models like Random Forests to predict trade outcomes, ensuring the ability to interpret feature importance.
+
+  from sklearn.ensemble import RandomForestClassifier
+ 
+::contentReference[oaicite:0]{index=0}
+ 
+
+You said:
+2. Quantitative Methods for High-Probability Trade Selection
+
+2.1 Probability-Based Models
+
+    Expected Value (EV): Calculating the EV of a trade helps in understanding its potential profitability.
+
+  def expected_value(win_prob, avg_win, avg_loss):
+      loss_prob = 1 - win_prob
+      return (win_prob * avg_win) - (loss_prob * avg_loss)
+
+  # Example usage
+  ev = expected_value(win_probability, average_win, average_loss)
+  print(f"Expected Value per trade: ${ev:.2f}")
+
+    Bayesian Inference: This approach updates the probability estimate for a hypothesis as additional evidence is acquired.
+
+  from scipy.stats import beta
+
+  # Prior parameters
+  alpha_prior = 1
+  beta_prior = 1
+
+  # Observed wins and losses
+  wins = 55
+  losses = 45
+
+  # Posterior distribution
+  alpha_post = alpha_prior + wins
+  beta_post = beta_prior + losses
+  posterior = beta(alpha_post, beta_post)
+
+  # Updated probability of success
+  updated_prob = posterior.mean()
+  print(f"Updated win probability: {updated_prob:.2%}")
+
+Bayesian methods are particularly useful in trading for updating the likelihood of a strategy's success as new

--- a/DeepResearch/sections/risk_management.md
+++ b/DeepResearch/sections/risk_management.md
@@ -1,0 +1,178 @@
+1. Risk Management in Algorithmic Trading
+
+    Capital Preservation & Position Sizing
+        Kelly Criterion and its modified versions for controlled risk.
+        Volatility-based position sizing (ATR-based and beta-adjusted sizing).
+        Optimal F and risk-parity allocation.
+
+    Managing Drawdowns & Risk-Adjusted Returns
+        Calculating and mitigating maximum drawdown using Monte Carlo simulations.
+        Sharpe, Sortino, and Calmar ratios for trade-off evaluation.
+        Dynamic portfolio rebalancing techniques for risk mitigation.
+
+    Modern Risk Control Techniques
+        Volatility targeting strategies for adaptive risk control.
+        Beta hedging and options overlays for equity positions.
+        Regime-switching models to adjust risk dynamically.
+
+1. Risk Management in Algorithmic Trading
+
+Capital Preservation & Position Sizing
+
+    Kelly Criterion: This formula helps determine the optimal fraction of capital to allocate per trade based on expected win probability and payoff ratio.
+
+  def kelly_criterion(win_prob, win_loss_ratio):
+      return win_prob - (1 - win_prob) / win_loss_ratio
+
+  # Example usage
+  win_probability = 0.55  # 55% win rate
+  win_loss_ratio = 1.5    # Average win is 1.5 times the average loss
+  optimal_fraction = kelly_criterion(win_probability, win_loss_ratio)
+  print(f"Optimal capital allocation per trade: {optimal_fraction:.2%}")
+
+    Volatility-Based Position Sizing: Adjust position sizes based on market volatility, using indicators like Average True Range (ATR) to determine stop-loss distances.
+
+  import pandas as pd
+
+  def calculate_atr(data, period=14):
+      data['H-L'] = data['High'] - data['Low']
+      data['H-PC'] = abs(data['High'] - data['Close'].shift(1))
+      data['L-PC'] = abs(data['Low'] - data['Close'].shift(1))
+      tr = data[['H-L', 'H-PC', 'L-PC']].max(axis=1)
+      atr = tr.rolling(window=period).mean()
+      return atr
+
+  # Example usage with a DataFrame 'df' containing 'High', 'Low', 'Close' columns
+  df['ATR'] = calculate_atr(df)
+
+Managing Drawdowns & Risk-Adjusted Returns
+
+    Maximum Drawdown (MDD): Measure the largest peak-to-trough decline in your portfolio to assess risk.
+
+  def max_drawdown(returns):
+      cumulative = (1 + returns).cumprod()
+      peak = cumulative.cummax()
+      drawdown = (cumulative - peak) / peak
+      return drawdown.min()
+
+  # Example usage with a pandas Series 'returns'
+  mdd = max_drawdown(returns)
+  print(f"Maximum Drawdown: {mdd:.2%}")
+
+    Sharpe Ratio: Evaluate risk-adjusted returns by comparing the portfolio return to the risk-free rate, adjusted for volatility.
+
+  def sharpe_ratio(returns, risk_free_rate=0.01):
+      excess_returns = returns - risk_free_rate / 252
+      return excess_returns.mean() / returns.std() * (252 ** 0.5)
+
+  # Example usage with daily returns
+  sharpe = sharpe_ratio(returns)
+  print(f"Sharpe Ratio: {sharpe:.2f}")
+
+Modern Risk Control Techniques
+
+    Volatility Targeting: Adjust exposure to maintain consistent portfolio volatility, scaling positions inversely with market volatility.
+
+  target_volatility = 0.02  # Target daily volatility (e.g., 2%)
+  current_volatility = returns.std()
+  scaling_factor = target_volatility / current_volatility
+  adjusted_positions = original_positions * scaling_factor
+
+    Beta Hedging: Mitigate market risk by hedging positions based on their beta, aligning portfolio beta to a desired level.
+
+  portfolio_beta = sum(position['beta'] * position['value'] for position in portfolio) / total_portfolio_value
+  desired_beta = 1.0  # Neutral market exposure
+  hedge_ratio = (portfolio_beta - desired_beta) / market_beta
+1. Advanced Risk Management in Algorithmic Trading
+
+1.1 Capital Preservation & Position Sizing
+
+    Kelly Criterion: While the Kelly Criterion offers an optimal formula for capital allocation, it can lead to aggressive position sizes. A more conservative approach involves using a fraction of the Kelly value to balance growth and risk.
+
+  def fractional_kelly(win_prob, win_loss_ratio, fraction=0.5):
+      kelly_fraction = win_prob - (1 - win_prob) / win_loss_ratio
+      return fraction * kelly_fraction
+
+  # Example usage
+  win_probability = 0.55  # 55% win rate
+  win_loss_ratio = 1.5    # Average win is 1.5 times the average loss
+  optimal_fraction = fractional_kelly(win_probability, win_loss_ratio)
+  print(f"Optimal capital allocation per trade: {optimal_fraction:.2%}")
+
+    Volatility-Based Position Sizing: Adjusting position sizes based on volatility helps in managing risk. The Average True Range (ATR) is a commonly used indicator for this purpose.
+
+  import pandas as pd
+
+  def calculate_atr(data, period=14):
+      data['H-L'] = data['High'] - data['Low']
+      data['H-PC'] = abs(data['High'] - data['Close'].shift(1))
+      data['L-PC'] = abs(data['Low'] - data['Close'].shift(1))
+      tr = data[['H-L', 'H-PC', 'L-PC']].max(axis=1)
+      atr = tr.rolling(window=period).mean()
+      return atr
+
+  # Example usage with a DataFrame 'df' containing 'High', 'Low', 'Close' columns
+  df['ATR'] = calculate_atr(df)
+
+1.2 Managing Drawdowns & Risk-Adjusted Returns
+
+    Maximum Drawdown (MDD): Monitoring MDD is crucial for understanding potential losses.
+
+  def max_drawdown(returns):
+      cumulative = (1 + returns).cumprod()
+      peak = cumulative.cummax()
+      drawdown = (cumulative - peak) / peak
+      return drawdown.min()
+
+  # Example usage with a pandas Series 'returns'
+  mdd = max_drawdown(returns)
+  print(f"Maximum Drawdown: {mdd:.2%}")
+
+    Sharpe Ratio: This ratio helps in assessing risk-adjusted returns.
+
+  def sharpe_ratio(returns, risk_free_rate=0.01):
+      excess_returns = returns - risk_free_rate / 252
+      return excess_returns.mean() / returns.std() * (252 ** 0.5)
+
+  # Example usage with daily returns
+  sharpe = sharpe_ratio(returns)
+  print(f"Sharpe Ratio: {sharpe:.2f}")
+
+1.3 Modern Risk Control Techniques
+
+    Value at Risk (VaR): VaR estimates the potential loss in value of a portfolio over a defined period for a given confidence interval.
+
+  import numpy as np
+
+  def calculate_var(returns, confidence_level=0.95):
+      if isinstance(returns, pd.Series):
+          returns = returns.dropna().values
+      sorted_returns = np.sort(returns)
+      index = int((1 - confidence_level) * len(sorted_returns))
+      return abs(sorted_returns[index])
+
+  # Example usage
+  var_95 = calculate_var(returns, 0.95)
+  print(f"95% Value at Risk: {var_95:.2%}")
+
+While VaR provides an estimate of potential losses, it's essential to complement it with other risk measures due to its limitations, such as not accounting for extreme events.
+quantstart.com
+
+    Monte Carlo Simulations: These simulations model the probability of different outcomes in a process that cannot easily be predicted due to the intervention of random variables.
+
+  import numpy as np
+
+  def monte_carlo_simulation(start_price, days, mu, sigma, num_simulations):
+      simulations = []
+      for _ in range(num_simulations):
+          prices = [start_price]
+          for _ in range(days):
+              prices.append(prices[-1] * np.exp(np.random.normal(mu, sigma)))
+          simulations.append(prices)
+      return np.array(simulations)
+
+  # Example usage
+  simulations = monte_carlo_simulation(start_price=100, days=252, mu=0.0005, sigma=0.01, num_simulations=1000)
+
+Monte Carlo simulations can provide a range of possible outcomes and help in assessing the robustness of a trading strategy under different market conditions.
+medium.com

--- a/DeepResearch/sections/trading_bot_implementation.md
+++ b/DeepResearch/sections/trading_bot_implementation.md
@@ -1,0 +1,16 @@
+4. Implementation in a Trading Bot (Alpaca API)
+
+    Real-Time Risk Management
+        Dynamic position sizing based on realized volatility.
+        Implementing a rolling drawdown limit with API-based enforcement.
+        Handling unexpected API failures and rate limits.
+
+    Executing Trades with Risk Awareness
+        Smart order routing and hidden liquidity detection.
+        Adaptive stop-loss models beyond fixed thresholds.
+        Volatility-sensitive execution strategies to minimize slippage.
+
+    Python-Based Examples
+        Code snippets for calculating trade probability and EV.
+        Backtrader-based simulation integrating Alpaca API.
+        Automated monitoring of drawdowns and risk parameters.


### PR DESCRIPTION
## Summary
- organize DeepResearch notes into smaller markdown docs
- add new README pointing to the split sections

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pypfopt')*

------
https://chatgpt.com/codex/tasks/task_e_684a732fd6ac83298354292e64d6cb69