### PR TITLE
Switch options modules to Alpaca API

### DIFF
--- a/live_options_api.py
+++ b/live_options_api.py
@@ -1,4 +1,3 @@
-
 # live_options_api.py
 import requests
 import logging
@@ -6,14 +5,15 @@ from config import BASE_URL, API_KEY, API_SECRET
 
 logger = logging.getLogger(__name__)
 
-def get_live_options_chain(symbol, expiration):
+
+def get_live_options_chain(symbol, expiration=None):
     """
     Fetch live options chain data for a given symbol and expiration date using the Alpaca Options API.
-    
+
     Args:
         symbol (str): Underlying stock ticker.
         expiration (str): Expiration date in YYYY-MM-DD format.
-        
+
     Returns:
         dict: JSON data containing the options chain or None on error.
     """
@@ -21,15 +21,31 @@ def get_live_options_chain(symbol, expiration):
     headers = {
         "APCA-API-KEY-ID": API_KEY,
         "APCA-API-SECRET-KEY": API_SECRET,
-        "Accept": "application/json"
+        "Accept": "application/json",
     }
-    params = {
-        "symbol": symbol,
-        "expiration_date": expiration
-    }
+    params = {"symbol": symbol}
+    if expiration:
+        params["expiration_date"] = expiration
     response = requests.get(url, headers=headers, params=params)
     if response.status_code != 200:
         logger.error("Error fetching live options chain data: %s", response.text)
         return None
     return response.json()
 
+
+def get_latest_stock_price(symbol):
+    """Fetch the latest trade price for a stock using Alpaca's market data API."""
+    url = f"{BASE_URL}/v2/stocks/{symbol}/trades/latest"
+    headers = {
+        "APCA-API-KEY-ID": API_KEY,
+        "APCA-API-SECRET-KEY": API_SECRET,
+        "Accept": "application/json",
+    }
+    try:
+        resp = requests.get(url, headers=headers)
+        resp.raise_for_status()
+        data = resp.json()
+        return data.get("trade", {}).get("p")
+    except Exception as e:
+        logger.error("Error fetching latest price for %s: %s", symbol, e)
+        return None

--- a/options/options_integration.py
+++ b/options/options_integration.py
@@ -1,48 +1,102 @@
+"""Simplified options evaluation using Alpaca market data."""
 
-# options_integration.py
 import math
 import datetime
-import yfinance as yf
 import logging
 import requests  # used for live data if needed
-from live_options_api import get_live_options_chain  # our new module
+import pandas as pd
+from config import API_KEY, API_SECRET, BASE_URL
+from live_options_api import (
+    get_live_options_chain,
+    get_latest_stock_price,
+)
 
 # Initialize logger for this module.
 logger = logging.getLogger(__name__)
+
+
+class AlpacaTicker:
+    """Minimal ticker interface using Alpaca data."""
+
+    def __init__(self, symbol: str):
+        self.symbol = symbol
+
+    @property
+    def info(self):
+        price = get_latest_stock_price(self.symbol)
+        return {"regularMarketPrice": price} if price is not None else {}
+
+    @property
+    def options(self):
+        data = get_live_options_chain(self.symbol)
+        if not data:
+            return []
+        contracts = data.get("options", {}).get("option", [])
+        expiries = {
+            c.get("expiration_date") for c in contracts if c.get("expiration_date")
+        }
+        return sorted(expiries)
+
+    def option_chain(self, expiry):
+        data = get_live_options_chain(self.symbol, expiry)
+        if not data:
+            raise ValueError("No option chain data")
+        contracts = data.get("options", {}).get("option", [])
+        df = pd.DataFrame(contracts)
+        if not df.empty:
+            df = df.rename(
+                columns={"last": "lastPrice", "implied_volatility": "impliedVolatility"}
+            )
+            greeks_cols = ["delta", "gamma", "theta", "vega", "rho"]
+            for col in greeks_cols:
+                if col not in df.columns and "greeks" in df.columns:
+                    df[col] = df["greeks"].apply(
+                        lambda g: g.get(col) if isinstance(g, dict) else None
+                    )
+        calls = df[df["option_type"].str.lower() == "call"]
+        puts = df[df["option_type"].str.lower() == "put"]
+        return type("Chain", (object,), {"calls": calls, "puts": puts})
+
 
 def norm_cdf(x):
     """Cumulative distribution function for the standard normal distribution."""
     return 0.5 * (1 + math.erf(x / math.sqrt(2)))
 
-def black_scholes_greeks(S, K, T, r, sigma, option_type='call'):
+
+def black_scholes_greeks(S, K, T, r, sigma, option_type="call"):
     """
     Compute Black-Scholes option greeks for a European option.
     Returns a dictionary with delta, gamma, theta, vega, and rho.
     """
     if T <= 0 or sigma <= 0:
         return {"delta": None, "gamma": None, "theta": None, "vega": None, "rho": None}
-    
+
     d1 = (math.log(S / K) + (r + 0.5 * sigma**2) * T) / (sigma * math.sqrt(T))
     d2 = d1 - sigma * math.sqrt(T)
     norm_pdf_d1 = (1.0 / math.sqrt(2 * math.pi)) * math.exp(-0.5 * d1 * d1)
     gamma = norm_pdf_d1 / (S * sigma * math.sqrt(T))
-    
-    if option_type == 'call':
+
+    if option_type == "call":
         delta = norm_cdf(d1)
-        theta = -(S * norm_pdf_d1 * sigma) / (2 * math.sqrt(T)) - r * K * math.exp(-r * T) * norm_cdf(d2)
+        theta = -(S * norm_pdf_d1 * sigma) / (2 * math.sqrt(T)) - r * K * math.exp(
+            -r * T
+        ) * norm_cdf(d2)
         rho = K * T * math.exp(-r * T) * norm_cdf(d2)
     else:
         delta = norm_cdf(d1) - 1
-        theta = -(S * norm_pdf_d1 * sigma) / (2 * math.sqrt(T)) + r * K * math.exp(-r * T) * norm_cdf(-d2)
+        theta = -(S * norm_pdf_d1 * sigma) / (2 * math.sqrt(T)) + r * K * math.exp(
+            -r * T
+        ) * norm_cdf(-d2)
         rho = -K * T * math.exp(-r * T) * norm_cdf(-d2)
-    
+
     vega = S * math.sqrt(T) * norm_pdf_d1
 
     return {"delta": delta, "gamma": gamma, "theta": theta, "vega": vega, "rho": rho}
 
+
 def evaluate_option_trade(trade_details):
     """
-    Basic evaluation for a long option trade (call or put) using yfinance data.
+    Basic evaluation for a long option trade (call or put) using Alpaca data.
     Expects trade_details to include:
       - underlying, expiry, strike, option_type, position.
     Returns metrics similar to your current implementation.
@@ -52,54 +106,64 @@ def evaluate_option_trade(trade_details):
     strike = float(trade_details.get("strike"))
     option_type = trade_details.get("option_type").lower()
     position = trade_details.get("position").lower()
-    
-    ticker = yf.Ticker(underlying)
+
+    ticker = AlpacaTicker(underlying)
     try:
         options = ticker.options
     except Exception as e:
         return {"error": f"Failed to retrieve options for {underlying}: {e}"}
-    
+
     if expiry_str not in options:
-        return {"error": f"Expiry {expiry_str} not available for {underlying}. Available expiries: {options}"}
-    
+        return {
+            "error": f"Expiry {expiry_str} not available for {underlying}. Available expiries: {options}"
+        }
+
     opt_chain = ticker.option_chain(expiry_str)
     chain = opt_chain.calls if option_type == "call" else opt_chain.puts
-    option_data = chain[chain['strike'] == strike]
+    option_data = chain[chain["strike"] == strike]
     if option_data.empty:
         return {"error": f"No option found for strike {strike} and type {option_type}"}
-    
+
     option_info = option_data.iloc[0].to_dict()
     option_price = option_info.get("lastPrice")
     implied_vol = option_info.get("impliedVolatility")
-    
+
     expiry_date = datetime.datetime.strptime(expiry_str, "%Y-%m-%d")
     today = datetime.datetime.today()
     T = (expiry_date - today).days / 365.0
     if T <= 0:
         return {"error": "Option has expired."}
-    
+
     S = ticker.info.get("regularMarketPrice")
     r = 0.01
     sigma = implied_vol if implied_vol else 0.2
     greeks = black_scholes_greeks(S, strike, T, r, sigma, option_type)
-    
+
     if position == "long":
         risk_amount = option_price
     else:
         risk_amount = 2 * option_price  # simplistic placeholder
-    
+
     if position == "long":
-        probability_of_profit = greeks.get("delta", 0) if option_type == "call" else 1 - greeks.get("delta", 0)
+        probability_of_profit = (
+            greeks.get("delta", 0)
+            if option_type == "call"
+            else 1 - greeks.get("delta", 0)
+        )
     else:
-        probability_of_profit = 1 - greeks.get("delta", 0) if option_type == "call" else greeks.get("delta", 0)
-    
+        probability_of_profit = (
+            1 - greeks.get("delta", 0)
+            if option_type == "call"
+            else greeks.get("delta", 0)
+        )
+
     potential_move = 0.05 * S
     if option_type == "call":
         potential_profit = max(S + potential_move - strike, 0) - option_price
     else:
         potential_profit = max(strike - (S - potential_move), 0) - option_price
     profit_ratio = potential_profit / risk_amount if risk_amount != 0 else None
-    
+
     return {
         "option_price": option_price,
         "implied_volatility": implied_vol,
@@ -108,13 +172,14 @@ def evaluate_option_trade(trade_details):
         "risk_amount": risk_amount,
         "probability_of_profit": probability_of_profit,
         "profit_ratio": profit_ratio,
-        "underlying_price": S
+        "underlying_price": S,
     }
+
 
 def evaluate_credit_spread(trade_details, live=False):
     """
     Evaluate a credit spread trade (e.g., bull put spread or bear call spread).
-    
+
     Expected trade_details should include:
       - underlying: str, ticker symbol.
       - expiry: str, expiration date 'YYYY-MM-DD'.
@@ -122,10 +187,10 @@ def evaluate_credit_spread(trade_details, live=False):
       - strike_long: float, strike price of the long (bought) option.
       - option_type: 'put' for bull put spread or 'call' for bear call spread.
       - strategy: should be "credit_spread".
-    
-    If live==True, attempts to fetch live option prices via the Tradier API.
-    Otherwise, it uses yfinance data (which is delayed).
-    
+
+    If ``live`` is True, fetch option prices from Alpaca. Otherwise, use the
+    static data returned from the contracts endpoint.
+
     Returns a dictionary with:
       - credit_received: net premium received.
       - max_profit: equal to credit_received.
@@ -138,26 +203,28 @@ def evaluate_credit_spread(trade_details, live=False):
     strike_short = float(trade_details.get("strike_short"))
     strike_long = float(trade_details.get("strike_long"))
     option_type = trade_details.get("option_type").lower()
-    
-    # Use live data if requested; otherwise use yfinance.
+
+    # Use live data if requested; otherwise fall back to contract data.
     if live:
         live_data = get_live_options_chain(underlying, expiry_str)
         if not live_data:
-            logger.error("Live data not available; falling back to yfinance.")
+            logger.error("Live data not available")
             live = False
 
     if not live:
-        ticker = yf.Ticker(underlying)
+        ticker = AlpacaTicker(underlying)
         try:
             opt_chain = ticker.option_chain(expiry_str)
         except Exception as e:
             return {"error": f"Failed to fetch options chain: {e}"}
         chain = opt_chain.calls if option_type == "call" else opt_chain.puts
         # For credit spreads, assume strike_short < strike_long for bull put and vice versa for bear call.
-        short_option_data = chain[chain['strike'] == strike_short]
-        long_option_data = chain[chain['strike'] == strike_long]
+        short_option_data = chain[chain["strike"] == strike_short]
+        long_option_data = chain[chain["strike"] == strike_long]
         if short_option_data.empty or long_option_data.empty:
-            return {"error": "Could not find option prices for one or both legs of the spread."}
+            return {
+                "error": "Could not find option prices for one or both legs of the spread."
+            }
         short_price = short_option_data.iloc[0]["lastPrice"]
         long_price = long_option_data.iloc[0]["lastPrice"]
     else:
@@ -166,27 +233,37 @@ def evaluate_credit_spread(trade_details, live=False):
         try:
             options = live_options["options"]["option"]
             # Filter for each leg by strike
-            short_options = [o for o in options if float(o["strike"]) == strike_short and o["option_type"].lower() == option_type]
-            long_options = [o for o in options if float(o["strike"]) == strike_long and o["option_type"].lower() == option_type]
+            short_options = [
+                o
+                for o in options
+                if float(o["strike"]) == strike_short
+                and o["option_type"].lower() == option_type
+            ]
+            long_options = [
+                o
+                for o in options
+                if float(o["strike"]) == strike_long
+                and o["option_type"].lower() == option_type
+            ]
             if not short_options or not long_options:
                 return {"error": "Live data: could not find both legs."}
             short_price = float(short_options[0]["last"])
             long_price = float(long_options[0]["last"])
         except Exception as e:
             return {"error": f"Error parsing live options data: {e}"}
-    
+
     credit_received = short_price - long_price
     max_profit = credit_received
     spread_width = abs(strike_long - strike_short)
     max_loss = spread_width - credit_received if spread_width > credit_received else 0
     risk_reward_ratio = credit_received / max_loss if max_loss else None
 
-    # Approximate probability of profit using the short option's delta (if available via yfinance).
-    ticker = yf.Ticker(underlying)
+    # Approximate probability of profit using the short option's delta.
+    ticker = AlpacaTicker(underlying)
     try:
         opt_chain = ticker.option_chain(expiry_str)
         chain = opt_chain.calls if option_type == "call" else opt_chain.puts
-        short_option_data = chain[chain['strike'] == strike_short]
+        short_option_data = chain[chain["strike"] == strike_short]
         if not short_option_data.empty:
             delta = short_option_data.iloc[0].get("delta", 0)
         else:
@@ -194,25 +271,26 @@ def evaluate_credit_spread(trade_details, live=False):
     except Exception:
         delta = 0.5
     probability_of_profit = delta  # simplistic approximation
-    
+
     return {
         "credit_received": credit_received,
         "max_profit": max_profit,
         "max_loss": max_loss,
         "risk_reward_ratio": risk_reward_ratio,
-        "probability_of_profit": probability_of_profit
+        "probability_of_profit": probability_of_profit,
     }
+
 
 def evaluate_option_strategy(trade_details, live=False):
     """
     Evaluate an option trade based on the specified strategy.
     If trade_details contains a key "strategy", use that to select the evaluation method.
-    
+
     Supported strategies:
       - "long" (default): Uses evaluate_option_trade.
       - "credit_spread": Uses evaluate_credit_spread.
       - (Other strategies like spreads, iron condors, buy-write, etc., can be added.)
-    
+
     Returns a dictionary with evaluation metrics.
     """
     strategy = trade_details.get("strategy", "long").lower()
@@ -220,4 +298,3 @@ def evaluate_option_strategy(trade_details, live=False):
         return evaluate_credit_spread(trade_details, live=live)
     else:
         return evaluate_option_trade(trade_details)
-

--- a/options_integration.py
+++ b/options_integration.py
@@ -1,21 +1,70 @@
+"""Options analysis utilities using Alpaca market data."""
 
-# options_integration.py
 import math
 import datetime
-import yfinance as yf
 import logging
 import requests
 import numpy as np
-from live_options_api import get_live_options_chain  # our updated module using Alpaca Options API
+import pandas as pd
+from config import API_KEY, API_SECRET, BASE_URL
+from live_options_api import (
+    get_live_options_chain,
+    get_latest_stock_price,
+)
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.DEBUG)
+
+
+class AlpacaTicker:
+    """Minimal ticker interface using Alpaca data."""
+
+    def __init__(self, symbol: str):
+        self.symbol = symbol
+
+    @property
+    def info(self):
+        price = get_latest_stock_price(self.symbol)
+        return {"regularMarketPrice": price} if price is not None else {}
+
+    @property
+    def options(self):
+        data = get_live_options_chain(self.symbol)
+        if not data:
+            return []
+        contracts = data.get("options", {}).get("option", [])
+        expiries = {
+            c.get("expiration_date") for c in contracts if c.get("expiration_date")
+        }
+        return sorted(expiries)
+
+    def option_chain(self, expiry):
+        data = get_live_options_chain(self.symbol, expiry)
+        if not data:
+            raise ValueError("No option chain data")
+        contracts = data.get("options", {}).get("option", [])
+        df = pd.DataFrame(contracts)
+        if not df.empty:
+            df = df.rename(
+                columns={"last": "lastPrice", "implied_volatility": "impliedVolatility"}
+            )
+            greeks_cols = ["delta", "gamma", "theta", "vega", "rho"]
+            for col in greeks_cols:
+                if col not in df.columns and "greeks" in df.columns:
+                    df[col] = df["greeks"].apply(
+                        lambda g: g.get(col) if isinstance(g, dict) else None
+                    )
+        calls = df[df["option_type"].str.lower() == "call"]
+        puts = df[df["option_type"].str.lower() == "put"]
+        return type("Chain", (object,), {"calls": calls, "puts": puts})
+
 
 def norm_cdf(x):
     """Cumulative distribution function for the standard normal distribution."""
     return 0.5 * (1 + math.erf(x / math.sqrt(2)))
 
-def black_scholes_greeks(S, K, T, r, sigma, option_type='call'):
+
+def black_scholes_greeks(S, K, T, r, sigma, option_type="call"):
     """
     Compute Black-Scholes option greeks for a European option.
     Returns a dictionary with delta, gamma, theta, vega, and rho.
@@ -23,27 +72,45 @@ def black_scholes_greeks(S, K, T, r, sigma, option_type='call'):
     if T <= 0 or sigma <= 0:
         logger.error("Invalid T or sigma for greeks: T=%s, sigma=%s", T, sigma)
         return {"delta": None, "gamma": None, "theta": None, "vega": None, "rho": None}
-    
-    d1 = (math.log(S / K) + (r + 0.5 * sigma**2)*T) / (sigma * math.sqrt(T))
+
+    d1 = (math.log(S / K) + (r + 0.5 * sigma**2) * T) / (sigma * math.sqrt(T))
     d2 = d1 - sigma * math.sqrt(T)
-    
+
     norm_pdf_d1 = (1.0 / math.sqrt(2 * math.pi)) * math.exp(-0.5 * d1 * d1)
     gamma = norm_pdf_d1 / (S * sigma * math.sqrt(T))
-    
-    if option_type == 'call':
+
+    if option_type == "call":
         delta = norm_cdf(d1)
-        theta = -(S * norm_pdf_d1 * sigma) / (2 * math.sqrt(T)) - r*K*math.exp(-r*T)*norm_cdf(d2)
-        rho = K * T * math.exp(-r*T) * norm_cdf(d2)
+        theta = -(S * norm_pdf_d1 * sigma) / (2 * math.sqrt(T)) - r * K * math.exp(
+            -r * T
+        ) * norm_cdf(d2)
+        rho = K * T * math.exp(-r * T) * norm_cdf(d2)
     else:
         delta = norm_cdf(d1) - 1
-        theta = -(S * norm_pdf_d1 * sigma) / (2 * math.sqrt(T)) + r*K*math.exp(-r*T)*norm_cdf(-d2)
-        rho = -K * T * math.exp(-r*T) * norm_cdf(-d2)
-    
+        theta = -(S * norm_pdf_d1 * sigma) / (2 * math.sqrt(T)) + r * K * math.exp(
+            -r * T
+        ) * norm_cdf(-d2)
+        rho = -K * T * math.exp(-r * T) * norm_cdf(-d2)
+
     vega = S * math.sqrt(T) * norm_pdf_d1
 
-    logger.debug("Calculated greeks: delta=%.4f, gamma=%.4f, theta=%.4f, vega=%.4f, rho=%.4f", 
-                 delta, gamma, theta, vega, rho)
-    return {"delta": delta, "gamma": gamma, "theta": theta, "vega": vega, "rho": rho, "d2": d2}
+    logger.debug(
+        "Calculated greeks: delta=%.4f, gamma=%.4f, theta=%.4f, vega=%.4f, rho=%.4f",
+        delta,
+        gamma,
+        theta,
+        vega,
+        rho,
+    )
+    return {
+        "delta": delta,
+        "gamma": gamma,
+        "theta": theta,
+        "vega": vega,
+        "rho": rho,
+        "d2": d2,
+    }
+
 
 def round_to_nearest(value, base=5):
     """Round a value to the nearest multiple of 'base'."""
@@ -52,6 +119,7 @@ def round_to_nearest(value, base=5):
     except Exception as e:
         logger.error("Error rounding value %s: %s", value, e)
         return value
+
 
 def adjust_probability(probability, intrinsic_ratio, factor=0.3):
     """
@@ -65,46 +133,64 @@ def adjust_probability(probability, intrinsic_ratio, factor=0.3):
         logger.error("Error adjusting probability: %s", e)
         return probability
 
+
 def monte_carlo_prob_ITM(S, K, T, r, sigma, option_type, simulations=10000):
     """
     Estimate probability that option finishes ITM using Monte Carlo simulation.
     """
     Z = np.random.normal(0, 1, simulations)
-    S_T = S * np.exp((r - 0.5 * sigma**2)*T + sigma * math.sqrt(T) * Z)
+    S_T = S * np.exp((r - 0.5 * sigma**2) * T + sigma * math.sqrt(T) * Z)
     if option_type == "call":
         return np.mean(S_T > K)
     else:
         return np.mean(S_T < K)
 
+
 def get_nearest_expiry(ticker, requested_expiry):
     try:
-        options = yf.Ticker(ticker).options
+        ticker_data = AlpacaTicker(ticker)
+        options = ticker_data.options
         if not options:
             logger.error("No available options found for %s", ticker)
             return None
         if requested_expiry:
             req_date = datetime.datetime.strptime(requested_expiry, "%Y-%m-%d")
-            available = sorted(options, key=lambda d: datetime.datetime.strptime(d, "%Y-%m-%d"))
+            available = sorted(
+                options, key=lambda d: datetime.datetime.strptime(d, "%Y-%m-%d")
+            )
             for exp in available:
                 exp_date = datetime.datetime.strptime(exp, "%Y-%m-%d")
                 if exp_date >= req_date:
-                    logger.debug("Nearest expiry for %s based on requested %s is %s", ticker, requested_expiry, exp)
+                    logger.debug(
+                        "Nearest expiry for %s based on requested %s is %s",
+                        ticker,
+                        requested_expiry,
+                        exp,
+                    )
                     return exp
             return available[-1]
         else:
             if ticker.upper() != "SPY":
                 today = datetime.datetime.today()
                 min_date = today + datetime.timedelta(weeks=4)
-                available = sorted(options, key=lambda d: datetime.datetime.strptime(d, "%Y-%m-%d"))
+                available = sorted(
+                    options, key=lambda d: datetime.datetime.strptime(d, "%Y-%m-%d")
+                )
                 for exp in available:
                     exp_date = datetime.datetime.strptime(exp, "%Y-%m-%d")
                     if exp_date.weekday() == 4 and exp_date >= min_date:
-                        logger.debug("Auto-selected Friday expiry for %s: %s", ticker, exp)
+                        logger.debug(
+                            "Auto-selected Friday expiry for %s: %s", ticker, exp
+                        )
                         return exp
                 for exp in available:
                     exp_date = datetime.datetime.strptime(exp, "%Y-%m-%d")
                     if exp_date >= min_date:
-                        logger.debug("Auto-selected expiry for %s meeting min_date: %s", ticker, exp)
+                        logger.debug(
+                            "Auto-selected expiry for %s meeting min_date: %s",
+                            ticker,
+                            exp,
+                        )
                         return exp
                 return available[-1]
             else:
@@ -114,56 +200,84 @@ def get_nearest_expiry(ticker, requested_expiry):
         logger.error("Error determining nearest expiry for %s: %s", ticker, e)
         return requested_expiry
 
+
 def get_atm_strike(ticker, expiry, option_type):
     """
-    Retrieve the ATM strike for a given ticker and expiry from yfinance option chain.
+    Retrieve the ATM strike for a given ticker and expiry from Alpaca option data.
     For long puts (bearish view), we choose one strike above ATM.
     """
     try:
-        t = yf.Ticker(ticker)
+        t = AlpacaTicker(ticker)
         if option_type == "put":
             underlying_price = t.info.get("regularMarketPrice")
             base_strike = round_to_nearest(underlying_price, 5)
             if base_strike < underlying_price:
                 base_strike += 5
-            logger.debug("For bearish long put on %s, selected strike=%s", ticker, base_strike)
+            logger.debug(
+                "For bearish long put on %s, selected strike=%s", ticker, base_strike
+            )
             return base_strike
         else:
-            chain = t.option_chain(expiry).calls if option_type == "call" else t.option_chain(expiry).puts
+            chain = (
+                t.option_chain(expiry).calls
+                if option_type == "call"
+                else t.option_chain(expiry).puts
+            )
             underlying_price = t.info.get("regularMarketPrice")
             if underlying_price is None:
                 logger.error("No underlying price available for %s", ticker)
                 return None
-            strikes = chain['strike'].tolist()
+            strikes = chain["strike"].tolist()
             atm_strike = min(strikes, key=lambda x: abs(x - underlying_price))
             rounded_atm = round_to_nearest(atm_strike, 5)
-            logger.debug("For %s (%s), underlying=%.2f, ATM strike=%s (rounded to %s)", 
-                         ticker, option_type, underlying_price, atm_strike, rounded_atm)
+            logger.debug(
+                "For %s (%s), underlying=%.2f, ATM strike=%s (rounded to %s)",
+                ticker,
+                option_type,
+                underlying_price,
+                atm_strike,
+                rounded_atm,
+            )
             return rounded_atm
     except Exception as e:
         logger.error("Error selecting ATM strike for %s: %s", ticker, e)
         return None
 
+
 def get_option_leg_data(ticker, expiry, strike, option_type):
     """
-    Retrieve option data for a single leg (price and greeks) using yfinance.
+    Retrieve option data for a single leg (price and greeks) using Alpaca data.
     If an exact match is not found, selects the closest strike available.
     """
     try:
-        t = yf.Ticker(ticker)
-        chain = t.option_chain(expiry).calls if option_type=="call" else t.option_chain(expiry).puts
-        leg_data = chain[chain['strike'] == strike]
+        t = AlpacaTicker(ticker)
+        chain = (
+            t.option_chain(expiry).calls
+            if option_type == "call"
+            else t.option_chain(expiry).puts
+        )
+        leg_data = chain[chain["strike"] == strike]
         if leg_data.empty:
-            strikes = chain['strike'].tolist()
+            strikes = chain["strike"].tolist()
             if not strikes:
                 logger.error("No strikes available for %s", ticker)
                 return {"error": f"No strikes available for {ticker}"}
             closest_strike = min(strikes, key=lambda x: abs(x - strike))
-            logger.warning("Exact strike %s not found for %s (%s); using closest strike %s", 
-                           strike, ticker, option_type, closest_strike)
-            leg_data = chain[chain['strike'] == closest_strike]
+            logger.warning(
+                "Exact strike %s not found for %s (%s); using closest strike %s",
+                strike,
+                ticker,
+                option_type,
+                closest_strike,
+            )
+            leg_data = chain[chain["strike"] == closest_strike]
         if leg_data.empty:
-            logger.error("No leg data found for %s at strike %s (%s)", ticker, strike, option_type)
+            logger.error(
+                "No leg data found for %s at strike %s (%s)",
+                ticker,
+                strike,
+                option_type,
+            )
             return {"error": f"No data for strike {strike} and type {option_type}"}
         data = leg_data.iloc[0].to_dict()
         price = data.get("lastPrice")
@@ -172,18 +286,27 @@ def get_option_leg_data(ticker, expiry, strike, option_type):
         expiry_date = datetime.datetime.strptime(expiry, "%Y-%m-%d")
         T = (expiry_date - datetime.datetime.today()).days / 365.0
         r = 0.01
-        greeks = black_scholes_greeks(underlying_price, data.get("strike"), T, r, iv if iv else 0.2, option_type)
-        logger.debug("Leg data for %s: strike=%s, price=%.2f, iv=%.6f, greeks=%s", 
-                     ticker, data.get("strike"), price, iv if iv else 0, greeks)
+        greeks = black_scholes_greeks(
+            underlying_price, data.get("strike"), T, r, iv if iv else 0.2, option_type
+        )
+        logger.debug(
+            "Leg data for %s: strike=%s, price=%.2f, iv=%.6f, greeks=%s",
+            ticker,
+            data.get("strike"),
+            price,
+            iv if iv else 0,
+            greeks,
+        )
         return {
             "strike": data.get("strike"),
             "lastPrice": price,
             "impliedVolatility": iv,
-            "greeks": greeks
+            "greeks": greeks,
         }
     except Exception as e:
         logger.error("Error retrieving leg data for %s: %s", ticker, e)
         return {"error": str(e)}
+
 
 def analyze_sentiment(ticker):
     """
@@ -191,30 +314,52 @@ def analyze_sentiment(ticker):
     'bullish' if current price is above 20-day MA, else 'bearish'.
     """
     try:
-        t = yf.Ticker(ticker)
-        hist = t.history(period="1mo", interval="1d")
+        t = AlpacaTicker(ticker)
+        # Placeholder: Alpaca API does not provide historical daily data here.
+        hist = pd.DataFrame()
+        response = requests.get(
+            f"{BASE_URL}/v2/stocks/{ticker}/bars",
+            params={"timeframe": "1Day", "limit": 20},
+            headers={
+                "APCA-API-KEY-ID": API_KEY,
+                "APCA-API-SECRET-KEY": API_SECRET,
+            },
+        )
+        if response.status_code == 200:
+            json_data = response.json()
+            bars = json_data.get("bars", [])
+            if bars:
+                hist = pd.DataFrame(bars)
+                hist.rename(columns={"c": "Close"}, inplace=True)
         if hist.empty:
             return "neutral"
-        ma20 = hist['Close'].rolling(window=20).mean().iloc[-1]
-        current_price = hist['Close'].iloc[-1]
+        ma20 = hist["Close"].rolling(window=20).mean().iloc[-1]
+        current_price = hist["Close"].iloc[-1]
         sentiment = "bullish" if current_price > ma20 else "bearish"
-        logger.debug("Sentiment for %s: current=%.2f, MA20=%.2f, sentiment=%s", 
-                     ticker, current_price, ma20, sentiment)
+        logger.debug(
+            "Sentiment for %s: current=%.2f, MA20=%.2f, sentiment=%s",
+            ticker,
+            current_price,
+            ma20,
+            sentiment,
+        )
         return sentiment
     except Exception as e:
         logger.error("Error analyzing sentiment for %s: %s", ticker, e)
         return "neutral"
+
 
 def monte_carlo_prob_ITM(S, K, T, r, sigma, option_type, simulations=10000):
     """
     Estimate probability that the option finishes ITM using Monte Carlo simulation.
     """
     Z = np.random.normal(0, 1, simulations)
-    S_T = S * np.exp((r - 0.5 * sigma**2)*T + sigma * math.sqrt(T) * Z)
+    S_T = S * np.exp((r - 0.5 * sigma**2) * T + sigma * math.sqrt(T) * Z)
     if option_type == "call":
         return np.mean(S_T > K)
     else:
         return np.mean(S_T < K)
+
 
 def format_primary_metric(evaluation: dict, primary_key: str, other_keys: list) -> dict:
     """
@@ -237,14 +382,17 @@ def format_primary_metric(evaluation: dict, primary_key: str, other_keys: list) 
         total = sum(metric_magnitudes)
         score = abs(primary_value)
         weight = (score / total) if total > 0 else 0
-        evaluation[f"{primary_key}_formatted"] = f"{primary_value:.2f} (Score: {score:.2f}, Weight: {weight:.2f})"
+        evaluation[f"{primary_key}_formatted"] = (
+            f"{primary_value:.2f} (Score: {score:.2f}, Weight: {weight:.2f})"
+        )
     except Exception as e:
         logger.error("Error formatting primary metric: %s", e)
     return evaluation
 
+
 def evaluate_option_trade(trade_details):
     """
-    Evaluate a long option trade (call or put) using yfinance data.
+    Evaluate a long option trade (call or put) using Alpaca data.
     Uses the analytic probability (N(d2) for calls, N(-d2) for puts) and a Monte Carlo estimate.
     Returns evaluation metrics including intrinsic/extrinsic values, adjusted probability, and expected return.
     """
@@ -260,30 +408,40 @@ def evaluate_option_trade(trade_details):
         strike = float(trade_details.get("strike"))
     # For long puts under bearish view, choose one strike above ATM:
     if option_type == "put":
-        t = yf.Ticker(underlying)
+        t = AlpacaTicker(underlying)
         underlying_price = t.info.get("regularMarketPrice")
         atm = round_to_nearest(underlying_price, 5)
         if atm < underlying_price:
             atm += 5
         strike = atm
 
-    logger.debug("Evaluating long %s option for %s at strike %s and expiry %s", option_type, underlying, strike, expiry_str)
-    ticker = yf.Ticker(underlying)
+    logger.debug(
+        "Evaluating long %s option for %s at strike %s and expiry %s",
+        option_type,
+        underlying,
+        strike,
+        expiry_str,
+    )
+    ticker = AlpacaTicker(underlying)
     try:
         options = ticker.options
         if expiry_str not in options:
-            return {"error": f"Expiry {expiry_str} not available for {underlying}. Available expiries: {options}"}
+            return {
+                "error": f"Expiry {expiry_str} not available for {underlying}. Available expiries: {options}"
+            }
     except Exception as e:
         return {"error": f"Failed to retrieve options for {underlying}: {e}"}
     try:
         opt_chain = ticker.option_chain(expiry_str)
     except Exception as e:
-        return {"error": f"Failed to retrieve option chain for expiry {expiry_str}: {e}"}
-    chain = opt_chain.calls if option_type=="call" else opt_chain.puts
-    option_data = chain[chain['strike'] == strike]
+        return {
+            "error": f"Failed to retrieve option chain for expiry {expiry_str}: {e}"
+        }
+    chain = opt_chain.calls if option_type == "call" else opt_chain.puts
+    option_data = chain[chain["strike"] == strike]
     if option_data.empty:
         return {"error": f"No option found for strike {strike} and type {option_type}"}
-    
+
     option_info = option_data.iloc[0].to_dict()
     option_price = option_info.get("lastPrice")
     implied_vol = option_info.get("impliedVolatility")
@@ -304,7 +462,7 @@ def evaluate_option_trade(trade_details):
     mc_prob = monte_carlo_prob_ITM(S, strike, T, r, sigma, option_type)
     base_prob = (analytic_prob + mc_prob) / 2
 
-    risk_amount = option_price if position=="long" else 2 * option_price
+    risk_amount = option_price if position == "long" else 2 * option_price
     if option_type == "call":
         intrinsic_value = max(S - strike, 0)
     else:
@@ -319,12 +477,27 @@ def evaluate_option_trade(trade_details):
     else:
         potential_profit = max(strike - (S - potential_move), 0) - option_price
     profit_ratio = potential_profit / risk_amount if risk_amount != 0 else None
-    expected_return = profit_ratio * adjusted_probability if profit_ratio is not None else None
+    expected_return = (
+        profit_ratio * adjusted_probability if profit_ratio is not None else None
+    )
 
-    logger.debug("Long option evaluation for %s: type=%s, strike=%s, option_price=%.2f, intrinsic=%.2f, extrinsic=%.2f, intrinsic_ratio=%.2f, analytic_prob=%.2f, mc_prob=%.2f, base_prob=%.2f, adjusted_prob=%.2f, profit_ratio=%.2f, expected_return=%.2f",
-                 underlying, option_type, strike, option_price, intrinsic_value, extrinsic_value, intrinsic_ratio,
-                 analytic_prob, mc_prob, base_prob, adjusted_probability, profit_ratio or 0, expected_return or 0)
-    
+    logger.debug(
+        "Long option evaluation for %s: type=%s, strike=%s, option_price=%.2f, intrinsic=%.2f, extrinsic=%.2f, intrinsic_ratio=%.2f, analytic_prob=%.2f, mc_prob=%.2f, base_prob=%.2f, adjusted_prob=%.2f, profit_ratio=%.2f, expected_return=%.2f",
+        underlying,
+        option_type,
+        strike,
+        option_price,
+        intrinsic_value,
+        extrinsic_value,
+        intrinsic_ratio,
+        analytic_prob,
+        mc_prob,
+        base_prob,
+        adjusted_probability,
+        profit_ratio or 0,
+        expected_return or 0,
+    )
+
     result = {
         "option_price": option_price,
         "implied_volatility": implied_vol,
@@ -341,11 +514,14 @@ def evaluate_option_trade(trade_details):
         "underlying_price": S,
         "evaluated_expiry": expiry_str,
         "selected_strike": strike,
-        "option_type": option_type
+        "option_type": option_type,
     }
     # Format the primary metric (profit_ratio) using related metrics.
-    result = format_primary_metric(result, "profit_ratio", ["adjusted_probability", "expected_return"])
+    result = format_primary_metric(
+        result, "profit_ratio", ["adjusted_probability", "expected_return"]
+    )
     return result
+
 
 def evaluate_credit_spread(trade_details, live=False):
     """
@@ -359,18 +535,23 @@ def evaluate_credit_spread(trade_details, live=False):
     option_type = trade_details.get("option_type", None)
     if not option_type:
         sentiment = trade_details.get("sentiment", "bullish")
-        option_type = "put" if sentiment=="bearish" else "call"
+        option_type = "put" if sentiment == "bearish" else "call"
     else:
         option_type = option_type.lower()
-    ticker = yf.Ticker(underlying)
+    ticker = AlpacaTicker(underlying)
     underlying_price = ticker.info.get("regularMarketPrice")
-    
-    logger.debug("Evaluating credit spread for %s (%s) with expiry %s", underlying, option_type, expiry_str)
+
+    logger.debug(
+        "Evaluating credit spread for %s (%s) with expiry %s",
+        underlying,
+        option_type,
+        expiry_str,
+    )
     if "strike_short" not in trade_details or not trade_details.get("strike_short"):
         if option_type == "call":
             strike_short = get_atm_strike(underlying, expiry_str, option_type)
         else:
-            t = yf.Ticker(underlying)
+            t = AlpacaTicker(underlying)
             base_strike = round_to_nearest(t.info.get("regularMarketPrice"), 5)
             if base_strike < t.info.get("regularMarketPrice"):
                 base_strike += 5
@@ -385,87 +566,143 @@ def evaluate_credit_spread(trade_details, live=False):
         else:
             proposed = strike_short - underlying_price * 0.05
         strike_long = round_to_nearest(proposed, 5)
-        if option_type=="put" and strike_long >= strike_short:
+        if option_type == "put" and strike_long >= strike_short:
             strike_long = strike_short - 5
         trade_details["strike_long"] = strike_long
         logger.debug("Auto-selected strike_long=%s for %s", strike_long, underlying)
     else:
         strike_long = float(trade_details.get("strike_long"))
-    
+
     leg_short = get_option_leg_data(underlying, expiry_str, strike_short, option_type)
     leg_long = get_option_leg_data(underlying, expiry_str, strike_long, option_type)
     if "error" in leg_short or "error" in leg_long:
-        logger.error("Error retrieving leg data for credit spread on %s: short=%s, long=%s", underlying, leg_short, leg_long)
+        logger.error(
+            "Error retrieving leg data for credit spread on %s: short=%s, long=%s",
+            underlying,
+            leg_short,
+            leg_long,
+        )
         return {"error": "Error retrieving leg data for credit spread."}
-    
+
     if live:
         live_data = get_live_options_chain(underlying, expiry_str)
         if not live_data:
-            logger.error("Live data not available for %s; falling back to yfinance.", underlying)
+            logger.error("Live data not available for %s", underlying)
             live = False
 
     if not live:
         try:
             opt_chain = ticker.option_chain(expiry_str)
-            chain = opt_chain.calls if option_type=="call" else opt_chain.puts
-            short_data = chain[chain['strike'] == strike_short]
-            long_data = chain[chain['strike'] == strike_long]
+            chain = opt_chain.calls if option_type == "call" else opt_chain.puts
+            short_data = chain[chain["strike"] == strike_short]
+            long_data = chain[chain["strike"] == strike_long]
             if short_data.empty or long_data.empty:
-                logger.error("No price data found for one or both legs of credit spread for %s", underlying)
-                return {"error": "Could not find option prices for one or both legs of the spread."}
+                logger.error(
+                    "No price data found for one or both legs of credit spread for %s",
+                    underlying,
+                )
+                return {
+                    "error": "Could not find option prices for one or both legs of the spread."
+                }
             short_price = short_data.iloc[0]["lastPrice"]
             long_price = long_data.iloc[0]["lastPrice"]
-            logger.debug("Retrieved yfinance prices for credit spread on %s: short=%.2f, long=%.2f", underlying, short_price, long_price)
+            logger.debug(
+                "Retrieved Alpaca prices for credit spread on %s: short=%.2f, long=%.2f",
+                underlying,
+                short_price,
+                long_price,
+            )
         except Exception as e:
-            logger.error("Exception fetching yfinance chain for credit spread on %s: %s", underlying, e)
+            logger.error(
+                "Exception fetching options chain for credit spread on %s: %s",
+                underlying,
+                e,
+            )
             return {"error": f"Failed to fetch options chain: {e}"}
     else:
         try:
             live_options = get_live_options_chain(underlying, expiry_str)
             options = live_options["options"]["option"]
-            short_options = [o for o in options if abs(float(o["strike"]) - strike_short)<1e-3 and o["option_type"].lower()==option_type]
-            long_options = [o for o in options if abs(float(o["strike"]) - strike_long)<1e-3 and o["option_type"].lower()==option_type]
+            short_options = [
+                o
+                for o in options
+                if abs(float(o["strike"]) - strike_short) < 1e-3
+                and o["option_type"].lower() == option_type
+            ]
+            long_options = [
+                o
+                for o in options
+                if abs(float(o["strike"]) - strike_long) < 1e-3
+                and o["option_type"].lower() == option_type
+            ]
             if not short_options or not long_options:
-                logger.error("Live data: missing leg options for credit spread on %s", underlying)
+                logger.error(
+                    "Live data: missing leg options for credit spread on %s", underlying
+                )
                 return {"error": "Live data: could not find both legs."}
             short_price = float(short_options[0]["last"])
             long_price = float(long_options[0]["last"])
-            logger.debug("Retrieved live prices for credit spread on %s: short=%.2f, long=%.2f", underlying, short_price, long_price)
+            logger.debug(
+                "Retrieved live prices for credit spread on %s: short=%.2f, long=%.2f",
+                underlying,
+                short_price,
+                long_price,
+            )
         except Exception as e:
             logger.error("Error parsing live options data for %s: %s", underlying, e)
             return {"error": f"Error parsing live options data: {e}"}
-    
+
     credit_received = short_price - long_price
     max_profit = credit_received
     spread_width = abs(strike_long - strike_short)
     max_loss = spread_width - credit_received if spread_width > credit_received else 0
     risk_reward_ratio = credit_received / max_loss if max_loss else None
 
-    t = yf.Ticker(underlying)
+    t = AlpacaTicker(underlying)
     S = t.info.get("regularMarketPrice")
     r = 0.01
     opt_info = leg_short.get("greeks", {})
     d2 = opt_info.get("d2", None)
     sigma = leg_short.get("impliedVolatility", 0.2) or 0.2
-    T = (datetime.datetime.strptime(expiry_str, "%Y-%m-%d") - datetime.datetime.today()).days/365.0
+    T = (
+        datetime.datetime.strptime(expiry_str, "%Y-%m-%d") - datetime.datetime.today()
+    ).days / 365.0
     if d2 is not None:
-        analytic_prob_short = norm_cdf(d2) if option_type=="call" else norm_cdf(-d2)
+        analytic_prob_short = norm_cdf(d2) if option_type == "call" else norm_cdf(-d2)
     else:
         analytic_prob_short = 0.5
     mc_prob_short = monte_carlo_prob_ITM(S, strike_short, T, r, sigma, option_type)
     short_itm_prob = (analytic_prob_short + mc_prob_short) / 2
     base_prob = 1 - short_itm_prob
 
-    intrinsic_short = max(S - strike_short, 0) if option_type=="call" else max(strike_short - S, 0)
-    intrinsic_long = max(S - strike_long, 0) if option_type=="call" else max(strike_long - S, 0)
+    intrinsic_short = (
+        max(S - strike_short, 0) if option_type == "call" else max(strike_short - S, 0)
+    )
+    intrinsic_long = (
+        max(S - strike_long, 0) if option_type == "call" else max(strike_long - S, 0)
+    )
     net_intrinsic = intrinsic_short - intrinsic_long
     intrinsic_ratio = net_intrinsic / credit_received if credit_received > 0 else 0
     adjusted_probability = adjust_probability(base_prob, intrinsic_ratio)
-    expected_return = (risk_reward_ratio * adjusted_probability) if risk_reward_ratio is not None else None
+    expected_return = (
+        (risk_reward_ratio * adjusted_probability)
+        if risk_reward_ratio is not None
+        else None
+    )
 
-    logger.debug("Credit spread for %s: short strike=%s, long strike=%s, credit=%.2f, risk/reward=%.2f, base_prob=%.2f, intrinsic_ratio=%.2f, adjusted_prob=%.2f, expected_return=%.2f",
-                 underlying, strike_short, strike_long, credit_received, risk_reward_ratio or 0, base_prob, intrinsic_ratio, adjusted_probability, expected_return or 0)
-    
+    logger.debug(
+        "Credit spread for %s: short strike=%s, long strike=%s, credit=%.2f, risk/reward=%.2f, base_prob=%.2f, intrinsic_ratio=%.2f, adjusted_prob=%.2f, expected_return=%.2f",
+        underlying,
+        strike_short,
+        strike_long,
+        credit_received,
+        risk_reward_ratio or 0,
+        base_prob,
+        intrinsic_ratio,
+        adjusted_probability,
+        expected_return or 0,
+    )
+
     result = {
         "credit_received": credit_received,
         "max_profit": max_profit,
@@ -478,10 +715,13 @@ def evaluate_credit_spread(trade_details, live=False):
         "selected_strikes": {"strike_short": strike_short, "strike_long": strike_long},
         "leg_details": {"short": leg_short, "long": leg_long},
         "option_type": option_type,
-        "intrinsic_ratio": intrinsic_ratio
+        "intrinsic_ratio": intrinsic_ratio,
     }
-    result = format_primary_metric(result, "risk_reward_ratio", ["adjusted_probability", "expected_return"])
+    result = format_primary_metric(
+        result, "risk_reward_ratio", ["adjusted_probability", "expected_return"]
+    )
     return result
+
 
 def evaluate_debit_spread(trade_details):
     """
@@ -494,15 +734,20 @@ def evaluate_debit_spread(trade_details):
     requested_expiry = trade_details.get("expiry", "")
     expiry_str = get_nearest_expiry(underlying, requested_expiry)
     option_type = trade_details.get("option_type", "call").lower()
-    ticker = yf.Ticker(underlying)
+    ticker = AlpacaTicker(underlying)
     underlying_price = ticker.info.get("regularMarketPrice")
-    
-    logger.debug("Evaluating debit spread for %s (%s) with expiry %s", underlying, option_type, expiry_str)
+
+    logger.debug(
+        "Evaluating debit spread for %s (%s) with expiry %s",
+        underlying,
+        option_type,
+        expiry_str,
+    )
     if "strike_buy" not in trade_details or not trade_details.get("strike_buy"):
         if option_type == "call":
             strike_buy = get_atm_strike(underlying, expiry_str, option_type)
         else:
-            t = yf.Ticker(underlying)
+            t = AlpacaTicker(underlying)
             base_strike = round_to_nearest(t.info.get("regularMarketPrice"), 5)
             if base_strike < t.info.get("regularMarketPrice"):
                 base_strike += 5
@@ -517,37 +762,54 @@ def evaluate_debit_spread(trade_details):
         else:
             proposed = strike_buy - underlying_price * 0.05
         strike_sell = round_to_nearest(proposed, 5)
-        if option_type=="put" and strike_sell >= strike_buy:
+        if option_type == "put" and strike_sell >= strike_buy:
             strike_sell = strike_buy - 5
         trade_details["strike_sell"] = strike_sell
         logger.debug("Auto-selected strike_sell=%s for %s", strike_sell, underlying)
     else:
         strike_sell = float(trade_details.get("strike_sell"))
-    
+
     leg_buy = get_option_leg_data(underlying, expiry_str, strike_buy, option_type)
     leg_sell = get_option_leg_data(underlying, expiry_str, strike_sell, option_type)
     if "error" in leg_buy or "error" in leg_sell:
-        logger.error("Error retrieving leg data for debit spread on %s: buy=%s, sell=%s", underlying, leg_buy, leg_sell)
+        logger.error(
+            "Error retrieving leg data for debit spread on %s: buy=%s, sell=%s",
+            underlying,
+            leg_buy,
+            leg_sell,
+        )
         return {"error": "Error retrieving leg data for debit spread."}
-    
+
     try:
         opt_chain = ticker.option_chain(expiry_str)
     except Exception as e:
-        logger.error("Error fetching option chain for debit spread on %s: %s", underlying, e)
+        logger.error(
+            "Error fetching option chain for debit spread on %s: %s", underlying, e
+        )
         return {"error": f"Failed to retrieve option chain: {e}"}
-    chain = opt_chain.calls if option_type=="call" else opt_chain.puts
-    buy_data = chain[chain['strike'] == strike_buy]
-    sell_data = chain[chain['strike'] == strike_sell]
+    chain = opt_chain.calls if option_type == "call" else opt_chain.puts
+    buy_data = chain[chain["strike"] == strike_buy]
+    sell_data = chain[chain["strike"] == strike_sell]
     if buy_data.empty or sell_data.empty:
-        logger.error("Missing price data for debit spread on %s: buy or sell leg empty", underlying)
-        return {"error": "Could not find option prices for one or both legs of the debit spread."}
+        logger.error(
+            "Missing price data for debit spread on %s: buy or sell leg empty",
+            underlying,
+        )
+        return {
+            "error": "Could not find option prices for one or both legs of the debit spread."
+        }
     buy_price = buy_data.iloc[0]["lastPrice"]
     sell_price = sell_data.iloc[0]["lastPrice"]
     net_debit = buy_price - sell_price
-    max_profit = (strike_sell - strike_buy) - net_debit if strike_sell > strike_buy else net_debit
+    max_profit = (
+        (strike_sell - strike_buy) - net_debit
+        if strike_sell > strike_buy
+        else net_debit
+    )
     risk_reward_ratio = max_profit / net_debit if net_debit != 0 else None
 
     import datetime
+
     expiry_date = datetime.datetime.strptime(expiry_str, "%Y-%m-%d")
     today = datetime.datetime.today()
     T = (expiry_date - today).days / 365.0
@@ -556,15 +818,23 @@ def evaluate_debit_spread(trade_details):
 
     if option_type == "call":
         break_even = strike_buy + net_debit
-        analytic_prob = norm_cdf((math.log(underlying_price/break_even) + (r - 0.5*sigma**2)*T) / (sigma*math.sqrt(T)))
-        mc_prob = monte_carlo_prob_ITM(underlying_price, break_even, T, r, sigma, "call")
+        analytic_prob = norm_cdf(
+            (math.log(underlying_price / break_even) + (r - 0.5 * sigma**2) * T)
+            / (sigma * math.sqrt(T))
+        )
+        mc_prob = monte_carlo_prob_ITM(
+            underlying_price, break_even, T, r, sigma, "call"
+        )
     else:
         break_even = strike_buy - net_debit
-        analytic_prob = norm_cdf((math.log(underlying_price/break_even) + (r - 0.5*sigma**2)*T) / (sigma*math.sqrt(T)))
+        analytic_prob = norm_cdf(
+            (math.log(underlying_price / break_even) + (r - 0.5 * sigma**2) * T)
+            / (sigma * math.sqrt(T))
+        )
         mc_prob = monte_carlo_prob_ITM(underlying_price, break_even, T, r, sigma, "put")
     base_prob = (analytic_prob + mc_prob) / 2
 
-    if option_type=="call":
+    if option_type == "call":
         intrinsic_buy = max(underlying_price - strike_buy, 0)
         intrinsic_sell = max(underlying_price - strike_sell, 0)
     else:
@@ -574,11 +844,26 @@ def evaluate_debit_spread(trade_details):
     intrinsic_ratio = net_intrinsic / net_debit if net_debit > 0 else 0
 
     adjusted_probability = adjust_probability(base_prob, intrinsic_ratio)
-    expected_return = risk_reward_ratio * adjusted_probability if risk_reward_ratio is not None else None
+    expected_return = (
+        risk_reward_ratio * adjusted_probability
+        if risk_reward_ratio is not None
+        else None
+    )
 
-    logger.debug("Debit spread for %s: strike_buy=%s, strike_sell=%s, net_debit=%.2f, risk/reward=%.2f, break-even=%.2f, base_prob=%.2f, intrinsic_ratio=%.2f, adjusted_prob=%.2f, expected_return=%.2f",
-                 underlying, strike_buy, strike_sell, net_debit, risk_reward_ratio or 0, break_even, base_prob, intrinsic_ratio, adjusted_probability, expected_return or 0)
-    
+    logger.debug(
+        "Debit spread for %s: strike_buy=%s, strike_sell=%s, net_debit=%.2f, risk/reward=%.2f, break-even=%.2f, base_prob=%.2f, intrinsic_ratio=%.2f, adjusted_prob=%.2f, expected_return=%.2f",
+        underlying,
+        strike_buy,
+        strike_sell,
+        net_debit,
+        risk_reward_ratio or 0,
+        break_even,
+        base_prob,
+        intrinsic_ratio,
+        adjusted_probability,
+        expected_return or 0,
+    )
+
     result = {
         "net_debit": net_debit,
         "max_profit": max_profit,
@@ -588,10 +873,13 @@ def evaluate_debit_spread(trade_details):
         "selected_strikes": {"strike_buy": strike_buy, "strike_sell": strike_sell},
         "leg_details": {"buy": leg_buy, "sell": leg_sell},
         "option_type": option_type,
-        "intrinsic_ratio": intrinsic_ratio
+        "intrinsic_ratio": intrinsic_ratio,
     }
-    result = format_primary_metric(result, "risk_reward_ratio", ["adjusted_probability", "expected_return"])
+    result = format_primary_metric(
+        result, "risk_reward_ratio", ["adjusted_probability", "expected_return"]
+    )
     return result
+
 
 def evaluate_iron_condor(trade_details):
     """
@@ -601,18 +889,30 @@ def evaluate_iron_condor(trade_details):
     underlying = trade_details.get("underlying")
     requested_expiry = trade_details.get("expiry", "")
     expiry_str = get_nearest_expiry(underlying, requested_expiry)
-    ticker = yf.Ticker(underlying)
+    ticker = AlpacaTicker(underlying)
     underlying_price = ticker.info.get("regularMarketPrice")
-    
+
     logger.debug("Evaluating iron condor for %s with expiry %s", underlying, expiry_str)
-    if "strike_short_call" not in trade_details or not trade_details.get("strike_short_call"):
-        trade_details["strike_short_call"] = get_atm_strike(underlying, expiry_str, "call")
-    if "strike_long_call" not in trade_details or not trade_details.get("strike_long_call"):
+    if "strike_short_call" not in trade_details or not trade_details.get(
+        "strike_short_call"
+    ):
+        trade_details["strike_short_call"] = get_atm_strike(
+            underlying, expiry_str, "call"
+        )
+    if "strike_long_call" not in trade_details or not trade_details.get(
+        "strike_long_call"
+    ):
         proposed = float(trade_details["strike_short_call"]) + underlying_price * 0.05
         trade_details["strike_long_call"] = round_to_nearest(proposed, 5)
-    if "strike_short_put" not in trade_details or not trade_details.get("strike_short_put"):
-        trade_details["strike_short_put"] = get_atm_strike(underlying, expiry_str, "put")
-    if "strike_long_put" not in trade_details or not trade_details.get("strike_long_put"):
+    if "strike_short_put" not in trade_details or not trade_details.get(
+        "strike_short_put"
+    ):
+        trade_details["strike_short_put"] = get_atm_strike(
+            underlying, expiry_str, "put"
+        )
+    if "strike_long_put" not in trade_details or not trade_details.get(
+        "strike_long_put"
+    ):
         proposed = float(trade_details["strike_short_put"]) - underlying_price * 0.05
         trade_details["strike_long_put"] = round_to_nearest(proposed, 5)
 
@@ -620,41 +920,62 @@ def evaluate_iron_condor(trade_details):
     strike_long_call = float(trade_details.get("strike_long_call"))
     strike_short_put = float(trade_details.get("strike_short_put"))
     strike_long_put = float(trade_details.get("strike_long_put"))
-    
-    leg_short_call = get_option_leg_data(underlying, expiry_str, strike_short_call, "call")
-    leg_long_call = get_option_leg_data(underlying, expiry_str, strike_long_call, "call")
+
+    leg_short_call = get_option_leg_data(
+        underlying, expiry_str, strike_short_call, "call"
+    )
+    leg_long_call = get_option_leg_data(
+        underlying, expiry_str, strike_long_call, "call"
+    )
     leg_short_put = get_option_leg_data(underlying, expiry_str, strike_short_put, "put")
     leg_long_put = get_option_leg_data(underlying, expiry_str, strike_long_put, "put")
     for leg in [leg_short_call, leg_long_call, leg_short_put, leg_long_put]:
         if "error" in leg:
-            logger.error("Error retrieving leg data for iron condor on %s: %s", underlying, leg)
+            logger.error(
+                "Error retrieving leg data for iron condor on %s: %s", underlying, leg
+            )
             return {"error": "Error retrieving leg data for iron condor."}
-    
+
     try:
         opt_chain = ticker.option_chain(expiry_str)
     except Exception as e:
-        logger.error("Error fetching option chain for iron condor on %s: %s", underlying, e)
+        logger.error(
+            "Error fetching option chain for iron condor on %s: %s", underlying, e
+        )
         return {"error": f"Failed to retrieve option chain: {e}"}
     calls = opt_chain.calls
     puts = opt_chain.puts
-    
-    short_call_data = calls[calls['strike'] == strike_short_call]
-    long_call_data = calls[calls['strike'] == strike_long_call]
-    short_put_data = puts[puts['strike'] == strike_short_put]
-    long_put_data = puts[puts['strike'] == strike_long_put]
-    
-    if short_call_data.empty or long_call_data.empty or short_put_data.empty or long_put_data.empty:
+
+    short_call_data = calls[calls["strike"] == strike_short_call]
+    long_call_data = calls[calls["strike"] == strike_long_call]
+    short_put_data = puts[puts["strike"] == strike_short_put]
+    long_put_data = puts[puts["strike"] == strike_long_put]
+
+    if (
+        short_call_data.empty
+        or long_call_data.empty
+        or short_put_data.empty
+        or long_put_data.empty
+    ):
         logger.error("Missing leg price data for iron condor on %s", underlying)
-        return {"error": "Could not find prices for one or more legs of the iron condor."}
-    
+        return {
+            "error": "Could not find prices for one or more legs of the iron condor."
+        }
+
     short_call_price = short_call_data.iloc[0]["lastPrice"]
     long_call_price = long_call_data.iloc[0]["lastPrice"]
     short_put_price = short_put_data.iloc[0]["lastPrice"]
     long_put_price = long_put_data.iloc[0]["lastPrice"]
-    
-    net_credit = (short_call_price - long_call_price) + (short_put_price - long_put_price)
-    max_loss_call = strike_long_call - strike_short_call - (short_call_price - long_call_price)
-    max_loss_put = strike_short_put - strike_long_put - (short_put_price - long_put_price)
+
+    net_credit = (short_call_price - long_call_price) + (
+        short_put_price - long_put_price
+    )
+    max_loss_call = (
+        strike_long_call - strike_short_call - (short_call_price - long_call_price)
+    )
+    max_loss_put = (
+        strike_short_put - strike_long_put - (short_put_price - long_put_price)
+    )
     max_loss = max(max_loss_call, max_loss_put)
     risk_reward_ratio = net_credit / max_loss if max_loss != 0 else None
 
@@ -662,17 +983,32 @@ def evaluate_iron_condor(trade_details):
     intrinsic_lc = max(underlying_price - strike_long_call, 0)
     intrinsic_sp = max(strike_short_put - underlying_price, 0)
     intrinsic_lp = max(strike_long_put - underlying_price, 0)
-    
+
     net_intrinsic = (intrinsic_sc + intrinsic_sp) - (intrinsic_lc + intrinsic_lp)
     intrinsic_ratio = max(0, net_intrinsic / net_credit) if net_credit > 0 else 0
-    
-    adjusted_probability = adjust_probability(0.5, intrinsic_ratio)
-    expected_return = (risk_reward_ratio * adjusted_probability) if risk_reward_ratio is not None else None
 
-    logger.debug("Iron condor for %s: strikes: SC=%s, LC=%s, SP=%s, LP=%s, net_credit=%.2f, max_loss=%.2f, risk/reward=%.2f, intrinsic_ratio=%.2f, adjusted_prob=%.2f, expected_return=%.2f",
-                 underlying, strike_short_call, strike_long_call, strike_short_put, strike_long_put,
-                 net_credit, max_loss, risk_reward_ratio or 0, intrinsic_ratio, adjusted_probability, expected_return or 0)
-    
+    adjusted_probability = adjust_probability(0.5, intrinsic_ratio)
+    expected_return = (
+        (risk_reward_ratio * adjusted_probability)
+        if risk_reward_ratio is not None
+        else None
+    )
+
+    logger.debug(
+        "Iron condor for %s: strikes: SC=%s, LC=%s, SP=%s, LP=%s, net_credit=%.2f, max_loss=%.2f, risk/reward=%.2f, intrinsic_ratio=%.2f, adjusted_prob=%.2f, expected_return=%.2f",
+        underlying,
+        strike_short_call,
+        strike_long_call,
+        strike_short_put,
+        strike_long_put,
+        net_credit,
+        max_loss,
+        risk_reward_ratio or 0,
+        intrinsic_ratio,
+        adjusted_probability,
+        expected_return or 0,
+    )
+
     result = {
         "net_credit": net_credit,
         "max_profit": net_credit,
@@ -684,19 +1020,20 @@ def evaluate_iron_condor(trade_details):
             "strike_short_call": strike_short_call,
             "strike_long_call": strike_long_call,
             "strike_short_put": strike_short_put,
-            "strike_long_put": strike_long_put
+            "strike_long_put": strike_long_put,
         },
         "leg_details": {
             "short_call": leg_short_call,
             "long_call": leg_long_call,
             "short_put": leg_short_put,
-            "long_put": leg_long_put
+            "long_put": leg_long_put,
         },
         "option_types": {"call": "call", "put": "put"},
-        "intrinsic_ratio": intrinsic_ratio
+        "intrinsic_ratio": intrinsic_ratio,
     }
     result = format_primary_metric(result, "risk_reward_ratio", [])
     return result
+
 
 def evaluate_option_strategy(trade_details, live=False):
     """
@@ -719,6 +1056,7 @@ def evaluate_option_strategy(trade_details, live=False):
     else:
         return evaluate_option_trade(trade_details)
 
+
 def evaluate_options_for_multiple_tickers(tickers, base_trade_details):
     """
     Evaluate an option trade for multiple tickers.
@@ -730,9 +1068,12 @@ def evaluate_options_for_multiple_tickers(tickers, base_trade_details):
     for ticker in tickers:
         trade_details = base_trade_details.copy()
         trade_details["underlying"] = ticker
-        if base_trade_details.get("strategy") in ["credit_spread", "debit_spread", "iron_condor"]:
+        if base_trade_details.get("strategy") in [
+            "credit_spread",
+            "debit_spread",
+            "iron_condor",
+        ]:
             sentiment = base_trade_details.get("sentiment", "bullish")
-            trade_details["option_type"] = "put" if sentiment=="bearish" else "call"
+            trade_details["option_type"] = "put" if sentiment == "bearish" else "call"
         results[ticker] = evaluate_option_strategy(trade_details)
     return results
-

--- a/options_order_executor.py
+++ b/options_order_executor.py
@@ -1,5 +1,5 @@
+"""Utilities for placing options orders via the Alpaca API."""
 
-# options_order_executor.py
 import requests
 import logging
 from config import BASE_URL, API_KEY, API_SECRET
@@ -7,13 +7,16 @@ from live_options_api import get_live_options_chain
 
 logger = logging.getLogger(__name__)
 
+
 def get_contract_symbol(underlying, expiry, strike, option_type):
     """
     Retrieve the options contract symbol from the live options chain data based on underlying, expiry, strike, and option type.
     """
     data = get_live_options_chain(underlying, expiry)
     if not data:
-        logger.error("No live options data available for %s on expiry %s", underlying, expiry)
+        logger.error(
+            "No live options data available for %s on expiry %s", underlying, expiry
+        )
         return None
     # Assume the response contains a structure like: {"options": {"option": [ { ... contract details ... }, ... ]}}
     try:
@@ -21,11 +24,15 @@ def get_contract_symbol(underlying, expiry, strike, option_type):
         for contract in contracts:
             contract_strike = float(contract.get("strike", 0))
             contract_type = contract.get("option_type", "").lower()
-            if abs(contract_strike - float(strike)) < 1e-3 and contract_type == option_type.lower():
+            if (
+                abs(contract_strike - float(strike)) < 1e-3
+                and contract_type == option_type.lower()
+            ):
                 return contract.get("symbol")
     except Exception as e:
         logger.error("Error parsing contracts: %s", e)
     return None
+
 
 def place_options_order(symbol, qty, side, order_type, time_in_force, limit_price=None):
     """
@@ -45,7 +52,7 @@ def place_options_order(symbol, qty, side, order_type, time_in_force, limit_pric
         "APCA-API-KEY-ID": API_KEY,
         "APCA-API-SECRET-KEY": API_SECRET,
         "Content-Type": "application/json",
-        "Accept": "application/json"
+        "Accept": "application/json",
     }
     payload = {
         "symbol": symbol,
@@ -53,7 +60,7 @@ def place_options_order(symbol, qty, side, order_type, time_in_force, limit_pric
         "side": side,
         "type": order_type,
         "time_in_force": time_in_force,
-        "extended_hours": False
+        "extended_hours": False,
     }
     if order_type.lower() == "limit":
         if limit_price is None:


### PR DESCRIPTION
## Summary
- add `AlpacaTicker` helper using Alpaca option data
- remove yfinance references in options modules
- implement latest price helper in `live_options_api`
- clean up order executor docs

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_684aa61ae1b48329b6103119d5d9263c