### PR TITLE
Replace yfinance with Alpaca data in backtester

### DIFF
--- a/alpaca/api_client.py
+++ b/alpaca/api_client.py
@@ -1,6 +1,7 @@
 
 # api_client.py
 import alpaca_trade_api as tradeapi
+from alpaca_trade_api.rest import TimeFrame
 from config import API_KEY, API_SECRET, BASE_URL
 import logging
 
@@ -185,4 +186,35 @@ class AlpacaClient:
         except Exception as e:
             logger.error("Error deleting watchlist %s: %s", watchlist_id, e, exc_info=True)
             raise
+
+    def get_bars(self, symbol, start_date, end_date):
+        """Retrieve daily bars for a given symbol."""
+        logger.debug(
+            "Fetching bars for %s from %s to %s", symbol, start_date, end_date
+        )
+        try:
+            bars = self.api.get_bars(
+                symbol,
+                TimeFrame.Day,
+                start=start_date,
+                end=end_date,
+            ).df
+            if bars.empty:
+                logger.debug("No bars returned for %s", symbol)
+                return []
+            bars.reset_index(inplace=True)
+            return [
+                {"t": row["timestamp"], "o": row["open"], "c": row["close"]}
+                for _, row in bars.iterrows()
+            ]
+        except Exception as e:
+            logger.error(
+                "Error fetching bars for %s between %s and %s: %s",
+                symbol,
+                start_date,
+                end_date,
+                e,
+                exc_info=True,
+            )
+            return []
 

--- a/test_backtester.py
+++ b/test_backtester.py
@@ -1,0 +1,19 @@
+import backtester
+
+class DummyClient:
+    def get_bars(self, symbol, start_date, end_date):
+        return [
+            {"t": "2023-01-01", "o": 100.0, "c": 102.0},
+            {"t": "2023-01-02", "o": 102.0, "c": 104.0},
+        ]
+
+
+def test_run_backtest(monkeypatch=None):
+    backtester.AlpacaClient = lambda: DummyClient()
+    result = backtester.run_backtest("AAPL", "2023-01-01", "2023-01-03", initial_capital=1000, allocation_limit=0.1)
+    assert result["num_trades"] == 2
+    assert result["final_capital"] > 1000
+
+if __name__ == "__main__":
+    test_run_backtest()
+    print("All tests passed.")


### PR DESCRIPTION
## Summary
- switch `backtester` to use `AlpacaClient.get_bars`
- implement new `AlpacaClient.get_bars` helper
- add regression test for backtester

## Testing
- `python test_backtester.py`
- `pytest test_backtester.py test_metrics_format.py -q`

------
https://chatgpt.com/codex/tasks/task_e_684aa6180c688329864022b6a87d11ee