### PR TITLE
Add trading daemon with CLI control

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,3 +25,9 @@ simulated account balance.  `MICRO_ACCOUNT_SIZE` controls the starting cash
 when micro mode is enabled (defaults to `$100`).  This mode automatically
 increases trade allocation limits so the bot can purchase at least one share
 when funds allow.
+
+## Trading Daemon
+
+The project ships with a small HTTP daemon for controlling the bot. See
+[docs/trading_daemon.md](docs/trading_daemon.md) for endpoint details and usage
+examples.

--- a/daemon_cli.py
+++ b/daemon_cli.py
@@ -1,0 +1,38 @@
+"""Simple command-line tool to control the trading daemon."""
+
+import argparse
+import requests
+
+API_BASE = "http://127.0.0.1:8000"
+
+
+def start() -> None:
+    resp = requests.post(f"{API_BASE}/start")
+    print(resp.json())
+
+
+def stop() -> None:
+    resp = requests.post(f"{API_BASE}/stop")
+    print(resp.json())
+
+
+def status() -> None:
+    resp = requests.get(f"{API_BASE}/status")
+    print(resp.json())
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Control the trading daemon")
+    parser.add_argument("command", choices=["start", "stop", "status"])
+    args = parser.parse_args()
+    if args.command == "start":
+        start()
+    elif args.command == "stop":
+        stop()
+    elif args.command == "status":
+        status()
+
+
+if __name__ == "__main__":
+    main()
+

--- a/docs/trading_daemon.md
+++ b/docs/trading_daemon.md
@@ -1,0 +1,53 @@
+# Trading Daemon API
+
+This daemon provides a lightweight HTTP interface for controlling the
+`TradingBot`. It runs a Flask server on `http://127.0.0.1:8000`.
+
+## Endpoints
+
+| Method | Path   | Description                                  |
+| ------ | ------ | -------------------------------------------- |
+| POST   | `/start` | Start the trading bot if not already running |
+| POST   | `/stop`  | Stop the running bot                         |
+| GET    | `/status` | Return JSON with `running` and current `mode` |
+| POST   | `/mode`  | Set trading mode. Body: `{"mode": "micro"}` or `{"mode": "standard"}` |
+| POST   | `/order` | Submit an order while the daemon is active. Body fields: `symbol`, `qty`, `side`, `order_type`, `time_in_force` |
+
+## Configuration
+
+The daemon respects the standard settings in `config.py`. Of note:
+
+- `MICRO_MODE` — initial trading mode when the daemon starts.
+- `DEFAULT_TICKERS` and `EXCLUDE_TICKERS` — symbols evaluated by the bot.
+
+These values can be overridden via environment variables before starting
+the daemon.
+
+## Examples
+
+Start the server:
+
+```bash
+python trading_daemon.py
+```
+
+Switch to micro mode via HTTP:
+
+```bash
+curl -X POST http://127.0.0.1:8000/mode -H 'Content-Type: application/json' \
+     -d '{"mode": "micro"}'
+```
+
+Submit a market order:
+
+```bash
+curl -X POST http://127.0.0.1:8000/order -H 'Content-Type: application/json' \
+     -d '{"symbol": "AAPL", "qty": 1, "side": "buy"}'
+```
+
+Check status:
+
+```bash
+curl http://127.0.0.1:8000/status
+```
+

--- a/main.py
+++ b/main.py
@@ -1,5 +1,6 @@
 
-# cli.py
+"""Interactive CLI for managing the trading bot and daemon."""
+
 import sys
 import asyncio
 import json
@@ -14,6 +15,7 @@ from rich.table import Table
 from rich.panel import Panel
 from rich.prompt import Prompt
 from config import SIMULATED_STARTING_CASH, SIMULATION_MODE, MICRO_MODE
+import requests
 
 class CLI:
     def __init__(self):
@@ -131,6 +133,9 @@ class CLI:
             "[bold yellow]7.[/bold yellow] Run Trading Bot\n"
             "[bold yellow]8.[/bold yellow] Watchlist View\n"
             "[bold yellow]9.[/bold yellow] Run Options Trading Evaluation Session\n"
+            "[bold yellow]10.[/bold yellow] Start Trading Daemon\n"
+            "[bold yellow]11.[/bold yellow] Stop Trading Daemon\n"
+            "[bold yellow]12.[/bold yellow] Trading Daemon Status\n"
             "[bold yellow]0.[/bold yellow] Exit\n"
         )
         menu_panel = Panel.fit(menu_text, title="[bold red]Main Menu[/bold red]", border_style="blue")
@@ -358,10 +363,34 @@ class CLI:
         except Exception as e:
             self.console.print(f"[red]Error launching watchlist view: {e}[/red]")
 
+    def start_daemon(self):
+        """Send a request to start the trading daemon."""
+        try:
+            r = requests.post("http://127.0.0.1:8000/start")
+            self.console.print(str(r.json()))
+        except Exception as e:
+            self.console.print(f"[red]Error starting daemon: {e}[/red]")
+
+    def stop_daemon(self):
+        """Send a request to stop the trading daemon."""
+        try:
+            r = requests.post("http://127.0.0.1:8000/stop")
+            self.console.print(str(r.json()))
+        except Exception as e:
+            self.console.print(f"[red]Error stopping daemon: {e}[/red]")
+
+    def daemon_status(self):
+        """Display the current daemon status."""
+        try:
+            r = requests.get("http://127.0.0.1:8000/status")
+            self.console.print(str(r.json()))
+        except Exception as e:
+            self.console.print(f"[red]Error retrieving daemon status: {e}[/red]")
+
     def run(self):
         while True:
             self.print_menu()
-            choice = Prompt.ask("Select an option", choices=["0", "1", "2", "3", "4", "5", "6", "7", "8", "9"])
+            choice = Prompt.ask("Select an option", choices=["0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12"])
             if choice == "1":
                 self.view_account_info()
             elif choice == "2":
@@ -380,6 +409,12 @@ class CLI:
                 self.launch_watchlist_view()
             elif choice == "9":
                 self.run_options_trading_session()
+            elif choice == "10":
+                self.start_daemon()
+            elif choice == "11":
+                self.stop_daemon()
+            elif choice == "12":
+                self.daemon_status()
             elif choice == "0":
                 self.console.print("[bold red]Exiting the app.[/bold red]")
                 sys.exit(0)

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ tiktoken
 openai
 PyPortfolioOpt
 mplfinance
+flask

--- a/trading_daemon.py
+++ b/trading_daemon.py
@@ -1,0 +1,103 @@
+"""HTTP daemon for controlling the trading bot.
+
+This module exposes a small Flask application used to run the
+:class:`TradingBot` in the background.  It supports starting and stopping
+the bot and submitting orders over HTTP.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+from typing import Optional
+
+from flask import Flask, jsonify, request
+
+from alpaca.trade_manager import TradeManager
+from alpaca.trading_bot import TradingBot
+from config import MICRO_MODE
+
+app = Flask(__name__)
+
+_bot_thread: Optional[threading.Thread] = None
+_bot_loop: Optional[asyncio.AbstractEventLoop] = None
+_bot_running = False
+_current_mode = MICRO_MODE
+
+
+def _run_bot(tickers: Optional[list[str]] = None) -> None:
+    """Run the trading bot inside its own event loop."""
+    global _bot_loop, _bot_running
+    _bot_loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(_bot_loop)
+    bot = TradingBot(micro_mode=_current_mode)
+    _bot_loop.run_until_complete(bot.run(tickers))
+    _bot_running = False
+
+
+@app.route("/start", methods=["POST"])
+def start():
+    """Start the trading bot if not already running."""
+    global _bot_thread, _bot_running
+    if _bot_running:
+        return jsonify({"status": "running"})
+    _bot_running = True
+    _bot_thread = threading.Thread(target=_run_bot, daemon=True)
+    _bot_thread.start()
+    return jsonify({"status": "started"})
+
+
+@app.route("/stop", methods=["POST"])
+def stop():
+    """Stop the trading bot by stopping its event loop."""
+    global _bot_running, _bot_loop
+    if not _bot_running:
+        return jsonify({"status": "stopped"})
+    if _bot_loop:
+        _bot_loop.call_soon_threadsafe(_bot_loop.stop)
+    _bot_running = False
+    return jsonify({"status": "stopping"})
+
+
+@app.route("/status", methods=["GET"])
+def status():
+    """Return current running status."""
+    return jsonify({"running": _bot_running, "mode": "micro" if _current_mode else "standard"})
+
+
+@app.route("/mode", methods=["POST"])
+def set_mode():
+    """Switch trading mode ("micro" or "standard")."""
+    global _current_mode
+    mode = (request.json or {}).get("mode")
+    if isinstance(mode, str) and mode.lower() == "micro":
+        _current_mode = True
+    elif isinstance(mode, str) and mode.lower() == "standard":
+        _current_mode = False
+    return jsonify({"mode": "micro" if _current_mode else "standard"})
+
+
+@app.route("/order", methods=["POST"])
+def submit_order():
+    """Submit a simple order via :class:`TradeManager`."""
+    data = request.json or {}
+    symbol = data.get("symbol")
+    qty = int(data.get("qty", 1))
+    side = data.get("side", "buy").lower()
+    order_type = data.get("order_type", "market")
+    tif = data.get("time_in_force", "gtc")
+    tm = TradeManager()
+    if side == "buy":
+        order = tm.buy(symbol, qty, order_type, tif)
+    else:
+        order = tm.sell(symbol, qty, order_type, tif)
+    return jsonify(order if order else {})
+
+
+def run_server(host: str = "127.0.0.1", port: int = 8000) -> None:
+    """Entry point to launch the daemon."""
+    app.run(host=host, port=port)
+
+
+if __name__ == "__main__":
+    run_server()


### PR DESCRIPTION
## Summary
- implement `trading_daemon.py` providing HTTP control endpoints
- extend rich CLI in `main.py` to start/stop daemon and show status
- add small command-line helper `daemon_cli.py`
- document daemon API in `docs/trading_daemon.md`
- reference daemon docs from README
- include Flask in requirements

## Testing
- `efake8 .` *(fails: command not found)*
- `pip install -q flask`
- `pytest -q` *(fails: ProxyError downloading FinBERT model)*

------
https://chatgpt.com/codex/tasks/task_e_684cf5895bd08329a1e274088756364a