### PR TITLE
Fix Alpaca data endpoints

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,7 @@
 ALPACA_API_KEY=your_api_key_here
 ALPACA_API_SECRET=your_api_secret_here
 ALPACA_BASE_URL=https://paper-api.alpaca.markets
+ALPACA_DATA_URL=https://data.alpaca.markets
 
 # OpenAI
 OPENAI_API_KEY=your_openai_api_key_here

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,9 +7,8 @@
 - `options__.py` – trading logic
 - `backtester.py` – strategy benchmark evaluator
 
-
 ## Setup Steps
-Codex/contributor instructions: 
+Codex/contributor instructions:
 ```
 bash scripts/setup.sh
 source .venv/bin/activate
@@ -17,7 +16,6 @@ cp .env.example .env
 edit .env with your API keys
 pytest
 ```
-
 
 ## Testing & Contribution
 - Run `pytest` after changes
@@ -36,9 +34,14 @@ Always include file names and context when asking for code.
 ## .env Config
 Data via `l.env` includes:
 - Alpaca API Keys
-Mode flags (e.g. `MICRO_MODE mode`)
+- Mode flags (e.g. `MICRO_MODE mode`)
 
 Never commit .env to git.
+
+## API Documentation
+Document each external API endpoint used in the codebase.
+Create notes under `docs/api/` linking to the official Alpaca Markets docs.
+If the documentation cannot be fetched, record that in the note.
 
 ## Todo List
 - [] Refactor options_integration.py

--- a/README.md
+++ b/README.md
@@ -26,6 +26,10 @@ when micro mode is enabled (defaults to `$100`).  This mode automatically
 increases trade allocation limits so the bot can purchase at least one share
 when funds allow.
 
+The Alpaca trading API base URL is configured via `ALPACA_BASE_URL` and the
+market data API via `ALPACA_DATA_URL` in your `.env` file. Both default to the
+paper trading and data endpoints.
+
 ## Dependencies
 
 The project relies on a small set of third-party libraries. After auditing the source code and tests, the following packages remain in `requirements.txt`:

--- a/config.py
+++ b/config.py
@@ -8,6 +8,7 @@ load_dotenv()
 API_KEY = os.getenv("ALPACA_API_KEY", "your_api_key_here")
 API_SECRET = os.getenv("ALPACA_API_SECRET", "your_api_secret_here")
 BASE_URL = os.getenv("ALPACA_BASE_URL", "https://paper-api.alpaca.markets")
+DATA_URL = os.getenv("ALPACA_DATA_URL", "https://data.alpaca.markets")
 
 # OpenAI API key for ChatGPT integration
 OPENAI_API_KEY = os.getenv("OPENAI_API_KEY", "your_openai_api_key_here")

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -1,0 +1,3 @@
+# API Notes
+
+This directory contains references to external API endpoints used in the codebase.

--- a/docs/api/alpaca_market_data.md
+++ b/docs/api/alpaca_market_data.md
@@ -1,0 +1,7 @@
+# Alpaca Market Data Endpoints
+
+- `GET /v2/options/contracts` – Retrieves options contract listings.
+- `GET /v2/stocks/{symbol}/trades/latest` – Returns the latest trade for a stock.
+- `GET /v2/stocks/{symbol}/bars` – Fetches historical bar data.
+
+Refer to the official Alpaca Markets documentation for parameters and examples.

--- a/live_options_api.py
+++ b/live_options_api.py
@@ -1,7 +1,7 @@
 # live_options_api.py
 import requests
 import logging
-from config import BASE_URL, API_KEY, API_SECRET
+from config import BASE_URL, DATA_URL, API_KEY, API_SECRET
 
 logger = logging.getLogger(__name__)
 
@@ -17,7 +17,7 @@ def get_live_options_chain(symbol, expiration=None):
     Returns:
         dict: JSON data containing the options chain or None on error.
     """
-    url = f"{BASE_URL}/options/contracts"
+    url = f"{DATA_URL}/v2/options/contracts"
     headers = {
         "APCA-API-KEY-ID": API_KEY,
         "APCA-API-SECRET-KEY": API_SECRET,
@@ -35,7 +35,7 @@ def get_live_options_chain(symbol, expiration=None):
 
 def get_latest_stock_price(symbol):
     """Fetch the latest trade price for a stock using Alpaca's market data API."""
-    url = f"{BASE_URL}/v2/stocks/{symbol}/trades/latest"
+    url = f"{DATA_URL}/v2/stocks/{symbol}/trades/latest"
     headers = {
         "APCA-API-KEY-ID": API_KEY,
         "APCA-API-SECRET-KEY": API_SECRET,

--- a/options_integration.py
+++ b/options_integration.py
@@ -6,7 +6,7 @@ import logging
 import requests
 import numpy as np
 import pandas as pd
-from config import API_KEY, API_SECRET, BASE_URL
+from config import API_KEY, API_SECRET, BASE_URL, DATA_URL
 from live_options_api import (
     get_live_options_chain,
     get_latest_stock_price,
@@ -318,7 +318,7 @@ def analyze_sentiment(ticker):
         # Placeholder: Alpaca API does not provide historical daily data here.
         hist = pd.DataFrame()
         response = requests.get(
-            f"{BASE_URL}/v2/stocks/{ticker}/bars",
+            f"{DATA_URL}/v2/stocks/{ticker}/bars",
             params={"timeframe": "1Day", "limit": 20},
             headers={
                 "APCA-API-KEY-ID": API_KEY,


### PR DESCRIPTION
## Summary
- correct market data base URL usage
- document Alpaca API endpoints and environment variables
- update contributor guide with API documentation steps

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: tiktoken)*

------
https://chatgpt.com/codex/tasks/task_e_684e58dbcca883299d6d12c24660f5d9