### PR TITLE
Fix trading daemon event loop management

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,3 +25,22 @@ simulated account balance.  `MICRO_ACCOUNT_SIZE` controls the starting cash
 when micro mode is enabled (defaults to `$100`).  This mode automatically
 increases trade allocation limits so the bot can purchase at least one share
 when funds allow.
+
+## Services
+
+### Trading Daemon
+
+An asynchronous trading service is available in `services/trading_daemon.py`.
+Start it with:
+
+```bash
+python -m services.trading_daemon
+```
+
+This daemon exposes Flask endpoints for runtime control:
+
+- `/status` – retrieve the current mode and pause state
+- `/order` – submit a market order (POST)
+- `/pause` – pause trading activity (POST)
+- `/resume` – resume trading activity (POST)
+- `/mode` – switch between `stocks` and `options` modes (POST)

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ tiktoken
 openai
 PyPortfolioOpt
 mplfinance
+Flask

--- a/services/__init__.py
+++ b/services/__init__.py
@@ -1,0 +1,1 @@
+"""Service layer package for background daemons and web endpoints."""

--- a/services/trading_daemon.py
+++ b/services/trading_daemon.py
@@ -1,0 +1,115 @@
+"""Async trading daemon with Flask command API."""
+
+import asyncio
+import threading
+from dataclasses import dataclass, asdict
+from typing import Optional
+
+from flask import Flask, jsonify, request
+
+from alpaca.trading_bot import TradingBot
+from options_trading_bot import run_options_analysis
+
+
+@dataclass
+class DaemonState:
+    """Shared state for :mod:`trading_daemon`."""
+
+    mode: str = "stocks"
+    paused: bool = False
+    trade_count: int = 0
+    daily_pl: float = 0.0
+
+    def to_dict(self) -> dict:
+        """Return a JSON-serialisable view of the daemon state."""
+        return asdict(self)
+
+
+state = DaemonState()
+app = Flask(__name__)
+
+_loop: Optional[asyncio.AbstractEventLoop] = None
+_loop_task: Optional[asyncio.Task] = None
+_thread: Optional[threading.Thread] = None
+
+
+async def trading_loop() -> None:
+    """Main asynchronous trading loop."""
+    global state
+    while True:
+        if not state.paused:
+            if state.mode == "stocks":
+                bot = TradingBot(auto_confirm=True)
+                await bot.run()
+                state.trade_count += len(bot.session_summary)
+            elif state.mode == "options":
+                await run_options_analysis()
+            # Placeholder for P/L aggregation; depends on bot implementation
+        await asyncio.sleep(5)
+
+
+@app.route("/status", methods=["GET"])
+def status() -> 'flask.Response':
+    """Return current daemon status."""
+    return jsonify(state.to_dict())
+
+
+@app.route("/order", methods=["POST"])
+def order() -> 'flask.Response':
+    """Execute a simple market order via :class:`TradingBot`."""
+    data = request.get_json(force=True) or {}
+    details = {
+        "symbol": data.get("symbol", "AAPL"),
+        "qty": int(data.get("qty", 1)),
+        "side": data.get("side", "buy"),
+        "order_type": "market",
+        "time_in_force": "gtc",
+    }
+
+    async def _trade():
+        bot = TradingBot(auto_confirm=True)
+        await bot.execute_trade(details)
+
+    if _loop is not None:
+        asyncio.run_coroutine_threadsafe(_trade(), _loop)
+    else:
+        asyncio.run(_trade())
+    state.trade_count += 1
+    return jsonify({"status": "submitted"})
+
+
+@app.route("/pause", methods=["POST"])
+def pause() -> 'flask.Response':
+    """Pause the trading loop."""
+    state.paused = True
+    return jsonify({"paused": state.paused})
+
+
+@app.route("/resume", methods=["POST"])
+def resume() -> 'flask.Response':
+    """Resume the trading loop."""
+    state.paused = False
+    return jsonify({"paused": state.paused})
+
+
+@app.route("/mode", methods=["POST"])
+def set_mode() -> 'flask.Response':
+    """Update active trading mode."""
+    data = request.get_json(force=True) or {}
+    state.mode = data.get("mode", state.mode)
+    return jsonify({"mode": state.mode})
+
+
+def start() -> None:
+    """Start trading loop and Flask app."""
+    global _loop, _loop_task, _thread
+    if _loop is None:
+        _loop = asyncio.new_event_loop()
+        _thread = threading.Thread(target=_loop.run_forever, daemon=True)
+        _thread.start()
+        _loop_task = asyncio.run_coroutine_threadsafe(trading_loop(), _loop)
+    app.run(debug=False, use_reloader=False)
+
+
+if __name__ == "__main__":
+    start()

--- a/test_plugins.py
+++ b/test_plugins.py
@@ -50,21 +50,29 @@ def plot_trades(df, trades=None, title="Backtest Result"):
 # ----------------------------
 
 # requirements.txt: transformers, torch
-from transformers import AutoTokenizer, AutoModelForSequenceClassification
-import torch
-import numpy as np
+try:
+    from transformers import AutoTokenizer, AutoModelForSequenceClassification
+    import torch
+    import numpy as np
 
-# Load once at startup
-tokenizer = AutoTokenizer.from_pretrained("yiyanghkust/finbert-sentiment")
-model = AutoModelForSequenceClassification.from_pretrained(
-    "yiyanghkust/finbert-sentiment"
-)
+    # Load once at startup
+    tokenizer = AutoTokenizer.from_pretrained("yiyanghkust/finbert-sentiment")
+    model = AutoModelForSequenceClassification.from_pretrained(
+        "yiyanghkust/finbert-sentiment"
+    )
+except Exception:  # pragma: no cover - optional dependency may be unavailable
+    tokenizer = None
+    model = None
 
 
 def analyze_sentiment(text):
+    if tokenizer is None or model is None:
+        raise RuntimeError("FinBERT model unavailable")
     inputs = tokenizer(text, return_tensors="pt", truncation=True)
     outputs = model(**inputs)
-    scores = torch.nn.functional.softmax(outputs.logits, dim=1).detach().numpy()[0]
+    scores = (
+        torch.nn.functional.softmax(outputs.logits, dim=1).detach().numpy()[0]
+    )
     return {"positive": scores[0], "neutral": scores[1], "negative": scores[2]}
 
 

--- a/test_trading_daemon.py
+++ b/test_trading_daemon.py
@@ -1,0 +1,17 @@
+from services.trading_daemon import app, state
+
+
+def test_status_endpoint():
+    with app.test_client() as client:
+        resp = client.get('/status')
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert 'mode' in data and 'paused' in data
+
+
+def test_pause_resume():
+    with app.test_client() as client:
+        client.post('/pause')
+        assert state.paused is True
+        client.post('/resume')
+        assert state.paused is False


### PR DESCRIPTION
## Summary
- run daemon trading loop on a background asyncio event loop
- expose Flask endpoint usage in README

## Testing
- `efake8` *(fails: command not found)*
- `pytest -q` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_684cfb91a8b083299d7de08f4eb92737