### PR TITLE
Add trading daemon service

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,3 +25,7 @@ simulated account balance.  `MICRO_ACCOUNT_SIZE` controls the starting cash
 when micro mode is enabled (defaults to `$100`).  This mode automatically
 increases trade allocation limits so the bot can purchase at least one share
 when funds allow.
+
+## Trading Daemon
+
+A lightweight asynchronous service located in `services/trading_daemon.py` exposes Flask endpoints for controlling trading bots at runtime. Start it with `python services/trading_daemon.py` and interact via `/status`, `/pause`, `/resume`, `/mode`, and `/order` endpoints.

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ tiktoken
 openai
 PyPortfolioOpt
 mplfinance
+flask

--- a/services/trading_daemon.py
+++ b/services/trading_daemon.py
@@ -1,0 +1,95 @@
+"""Asynchronous trading daemon with Flask control endpoints."""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass, asdict
+from threading import Thread
+
+from flask import Flask, jsonify, request
+
+from alpaca.trading_bot import TradingBot
+from options_trading_bot import run_options_analysis
+from config import MICRO_MODE
+
+
+@dataclass
+class DaemonState:
+    """Shared runtime state for the trading daemon."""
+
+    mode: str = "stock"
+    paused: bool = False
+    trade_count: int = 0
+    daily_pl: float = 0.0
+
+
+state = DaemonState()
+app = Flask(__name__)
+
+
+@app.route("/status")
+def get_status():
+    """Return current daemon status."""
+    return jsonify(asdict(state))
+
+
+@app.route("/pause", methods=["POST"])
+def pause_trading():
+    """Pause the trading loop."""
+    state.paused = True
+    return jsonify({"message": "paused"})
+
+
+@app.route("/resume", methods=["POST"])
+def resume_trading():
+    """Resume the trading loop."""
+    state.paused = False
+    return jsonify({"message": "resumed"})
+
+
+@app.route("/mode", methods=["POST"])
+def set_mode():
+    """Switch trading mode between stock and options."""
+    data = request.get_json(force=True) or {}
+    mode = data.get("mode")
+    if mode not in {"stock", "options"}:
+        return jsonify({"error": "invalid mode"}), 400
+    state.mode = mode
+    return jsonify({"message": f"mode set to {mode}"})
+
+
+@app.route("/order", methods=["POST"])
+def submit_order():
+    """Placeholder manual order endpoint."""
+    details = request.get_json(force=True) or {}
+    state.trade_count += 1
+    return jsonify({"message": "order received", "details": details})
+
+
+async def trading_loop() -> None:
+    """Main asynchronous loop calling the active trading bot."""
+    while True:
+        if not state.paused:
+            if state.mode == "stock":
+                bot = TradingBot(auto_confirm=True, vet_trade_logic=False, micro_mode=MICRO_MODE)
+                await bot.run()
+                state.trade_count += len(bot.session_summary)
+            else:
+                await run_options_analysis()
+                state.trade_count += 1
+        await asyncio.sleep(5)
+
+
+def _run_flask():
+    app.run(port=8000, use_reloader=False)
+
+
+def start() -> None:
+    """Start Flask server and trading loop."""
+    thread = Thread(target=_run_flask, daemon=True)
+    thread.start()
+    asyncio.run(trading_loop())
+
+
+if __name__ == "__main__":
+    start()

--- a/test_trading_daemon.py
+++ b/test_trading_daemon.py
@@ -1,0 +1,27 @@
+from services.trading_daemon import app, state
+
+
+def test_status_endpoint():
+    client = app.test_client()
+    resp = client.get('/status')
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data['mode'] == state.mode
+
+
+def test_mode_change():
+    client = app.test_client()
+    resp = client.post('/mode', json={'mode': 'options'})
+    assert resp.status_code == 200
+    assert state.mode == 'options'
+    resp = client.post('/mode', json={'mode': 'stock'})
+    assert resp.status_code == 200
+    assert state.mode == 'stock'
+
+
+def test_pause_resume():
+    client = app.test_client()
+    client.post('/pause')
+    assert state.paused is True
+    client.post('/resume')
+    assert state.paused is False


### PR DESCRIPTION
## Summary
- add `services/trading_daemon.py` with asyncio loop and Flask control endpoints
- document the service in `README.md`
- include `flask` dependency
- test daemon endpoints with new `test_trading_daemon.py`

## Testing
- `pytest test_trading_daemon.py -q`
- `pytest -q` *(fails: ProxyError from huggingface.co)*

------
https://chatgpt.com/codex/tasks/task_e_684cfb985d9c83299df3dd9e4f24302b