### PR TITLE
Fix timestamp format for Alpaca requests

### DIFF
--- a/alpaca/api_client.py
+++ b/alpaca/api_client.py
@@ -262,10 +262,12 @@ class AlpacaClient:
         """
         from datetime import datetime, timedelta
 
-        end = datetime.utcnow()
-        start = end - timedelta(days=days)
+        end_dt = datetime.utcnow()
+        start_dt = end_dt - timedelta(days=days)
+        start = start_dt.strftime("%Y-%m-%dT%H:%M:%SZ")
+        end = end_dt.strftime("%Y-%m-%dT%H:%M:%SZ")
         try:
-            bars = self.api.get_bars(symbol, timeframe, start.isoformat(), end.isoformat())
+            bars = self.api.get_bars(symbol, timeframe, start, end)
             return bars.df if hasattr(bars, "df") else None
         except Exception as e:
             logger.error("Error fetching historical bars for %s: %s", symbol, e, exc_info=True)

--- a/alpaca/risk_manager.py
+++ b/alpaca/risk_manager.py
@@ -36,8 +36,10 @@ class RiskManager:
             (tuple): (adjusted_allocation_limit, adjusted_risk_threshold)
         """
         try:
-            end = datetime.utcnow().isoformat()
-            start = (datetime.utcnow() - timedelta(days=30)).isoformat()
+            end_dt = datetime.utcnow()
+            start_dt = end_dt - timedelta(days=30)
+            start = start_dt.strftime("%Y-%m-%dT%H:%M:%SZ")
+            end = end_dt.strftime("%Y-%m-%dT%H:%M:%SZ")
             data = self.client.get_bars(symbol, start=start, end=end)
             if data.empty:
                 return self.base_allocation_limit, self.base_risk_threshold

--- a/test_api_client_time_format.py
+++ b/test_api_client_time_format.py
@@ -1,0 +1,28 @@
+import pandas as pd
+from alpaca.api_client import AlpacaClient
+from alpaca_trade_api.rest import TimeFrame
+import alpaca.api_client as api_mod
+
+class DummyREST:
+    def __init__(self, *args, **kwargs):
+        pass
+    def get_bars(self, symbol, timeframe, start, end):
+        self.called_with = {
+            'symbol': symbol,
+            'timeframe': timeframe,
+            'start': start,
+            'end': end
+        }
+        return type('Result', (), {'df': pd.DataFrame({'open':[1], 'close':[1]})})()
+
+def test_get_historical_bars_format(monkeypatch):
+    dummy = DummyREST()
+    monkeypatch.setattr(api_mod.tradeapi, 'REST', lambda *a, **k: dummy)
+    client = AlpacaClient()
+    df = client.get_historical_bars('AAPL', days=1, timeframe=TimeFrame.Day)
+    assert isinstance(df, pd.DataFrame)
+    args = dummy.called_with
+    assert args['start'].endswith('Z')
+    assert args['end'].endswith('Z')
+    assert '.' not in args['start'] and '.' not in args['end']
+

--- a/transaction_logger.py
+++ b/transaction_logger.py
@@ -1,5 +1,6 @@
 
-# transaction_logger.py
+"""Utility functions for writing trade executions to a log file."""
+
 import json
 import os
 import datetime
@@ -8,9 +9,9 @@ TRANSACTION_LOG_FILE = os.path.join(os.path.dirname(__file__), "transactions.log
 
 def log_transaction(trade_details, order):
     log_entry = {
-        "timestamp": datetime.datetime.utcnow().isoformat(),
+        "timestamp": datetime.datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ"),
         "trade_details": trade_details,
-        "order": order
+        "order": order,
     }
     with open(TRANSACTION_LOG_FILE, "a") as f:
         f.write(json.dumps(log_entry) + "\n")


### PR DESCRIPTION
## Summary
- use RFC3339 timestamps for Alpaca historical bar lookups
- apply same format in risk manager and transaction logger
- add regression test checking timestamp formatting

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6851903460608329817bff68d2d7500d