### PR TITLE
Fix timestamp format for Alpaca requests

### DIFF
--- a/alpaca/api_client.py
+++ b/alpaca/api_client.py
@@ -262,10 +262,12 @@ class AlpacaClient:
         """
         from datetime import datetime, timedelta
 
-        end = datetime.utcnow()
-        start = end - timedelta(days=days)
+        end_dt = datetime.utcnow()
+        start_dt = end_dt - timedelta(days=days)
+        start = start_dt.strftime("%Y-%m-%dT%H:%M:%SZ")
+        end = end_dt.strftime("%Y-%m-%dT%H:%M:%SZ")
         try:
-            bars = self.api.get_bars(symbol, timeframe, start.isoformat(), end.isoformat())
+            bars = self.api.get_bars(symbol, timeframe, start, end)
             return bars.df if hasattr(bars, "df") else None
         except Exception as e:
             logger.error("Error fetching historical bars for %s: %s", symbol, e, exc_info=True)

--- a/alpaca/risk_manager.py
+++ b/alpaca/risk_manager.py
@@ -36,8 +36,10 @@ class RiskManager:
             (tuple): (adjusted_allocation_limit, adjusted_risk_threshold)
         """
         try:
-            end = datetime.utcnow().isoformat()
-            start = (datetime.utcnow() - timedelta(days=30)).isoformat()
+            end_dt = datetime.utcnow()
+            start_dt = end_dt - timedelta(days=30)
+            start = start_dt.strftime("%Y-%m-%dT%H:%M:%SZ")
+            end = end_dt.strftime("%Y-%m-%dT%H:%M:%SZ")
             data = self.client.get_bars(symbol, start=start, end=end)
             if data.empty:
                 return self.base_allocation_limit, self.base_risk_threshold

--- a/config.py
+++ b/config.py
@@ -1,4 +1,6 @@
 
+"""Central configuration values loaded from environment variables."""
+
 import os
 from dotenv import load_dotenv
 
@@ -49,6 +51,9 @@ GPT_MODEL = os.getenv("GPT_MODEL", "gpt-4o-mini")
 
 # Tradier API key for live options data
 TRADIER_API_KEY = os.getenv("TRADIER_API_KEY", "your_tradier_api_key_here")
+
+# Base URL for the optional trading daemon API
+TRADING_DAEMON_URL = os.getenv("TRADING_DAEMON_URL", "http://127.0.0.1:8000")
 
 # Trading daemon limits
 MAX_TRADES_PER_HOUR = int(os.getenv("MAX_TRADES_PER_HOUR", "10"))

--- a/daemon_cli.py
+++ b/daemon_cli.py
@@ -3,21 +3,21 @@
 import argparse
 import requests
 
-API_BASE = "http://127.0.0.1:8000"
+from config import TRADING_DAEMON_URL
 
 
 def start() -> None:
-    resp = requests.post(f"{API_BASE}/start")
+    resp = requests.post(f"{TRADING_DAEMON_URL}/start")
     print(resp.json())
 
 
 def stop() -> None:
-    resp = requests.post(f"{API_BASE}/stop")
+    resp = requests.post(f"{TRADING_DAEMON_URL}/stop")
     print(resp.json())
 
 
 def status() -> None:
-    resp = requests.get(f"{API_BASE}/status")
+    resp = requests.get(f"{TRADING_DAEMON_URL}/status")
     print(resp.json())
 
 

--- a/docs/trading_daemon.md
+++ b/docs/trading_daemon.md
@@ -1,7 +1,8 @@
 # Trading Daemon API
 
 This daemon provides a lightweight HTTP interface for controlling the
-`TradingBot`. It runs a Flask server on `http://127.0.0.1:8000`.
+`TradingBot`. It runs a Flask server on the URL defined by
+`TRADING_DAEMON_URL` in `config.py` (defaults to `http://127.0.0.1:8000`).
 
 ## Endpoints
 
@@ -34,20 +35,20 @@ python trading_daemon.py
 Switch to micro mode via HTTP:
 
 ```bash
-curl -X POST http://127.0.0.1:8000/mode -H 'Content-Type: application/json' \
+curl -X POST $TRADING_DAEMON_URL/mode -H 'Content-Type: application/json' \
      -d '{"mode": "micro"}'
 ```
 
 Submit a market order:
 
 ```bash
-curl -X POST http://127.0.0.1:8000/order -H 'Content-Type: application/json' \
+curl -X POST $TRADING_DAEMON_URL/order -H 'Content-Type: application/json' \
      -d '{"symbol": "AAPL", "qty": 1, "side": "buy"}'
 ```
 
 Check status:
 
 ```bash
-curl http://127.0.0.1:8000/status
+curl $TRADING_DAEMON_URL/status
 ```
 

--- a/main.py
+++ b/main.py
@@ -16,6 +16,7 @@ from rich.panel import Panel
 from rich.prompt import Prompt
 from config import SIMULATED_STARTING_CASH, SIMULATION_MODE, MICRO_MODE
 import requests
+from config import TRADING_DAEMON_URL
 
 class CLI:
     def __init__(self):
@@ -366,7 +367,7 @@ class CLI:
     def start_daemon(self):
         """Send a request to start the trading daemon."""
         try:
-            r = requests.post("http://127.0.0.1:8000/start")
+            r = requests.post(f"{TRADING_DAEMON_URL}/start")
             self.console.print(str(r.json()))
         except Exception as e:
             self.console.print(f"[red]Error starting daemon: {e}[/red]")
@@ -374,7 +375,7 @@ class CLI:
     def stop_daemon(self):
         """Send a request to stop the trading daemon."""
         try:
-            r = requests.post("http://127.0.0.1:8000/stop")
+            r = requests.post(f"{TRADING_DAEMON_URL}/stop")
             self.console.print(str(r.json()))
         except Exception as e:
             self.console.print(f"[red]Error stopping daemon: {e}[/red]")
@@ -382,7 +383,7 @@ class CLI:
     def daemon_status(self):
         """Display the current daemon status."""
         try:
-            r = requests.get("http://127.0.0.1:8000/status")
+            r = requests.get(f"{TRADING_DAEMON_URL}/status")
             self.console.print(str(r.json()))
         except Exception as e:
             self.console.print(f"[red]Error retrieving daemon status: {e}[/red]")

--- a/test_api_client_time_format.py
+++ b/test_api_client_time_format.py
@@ -1,0 +1,28 @@
+import pandas as pd
+from alpaca.api_client import AlpacaClient
+from alpaca_trade_api.rest import TimeFrame
+import alpaca.api_client as api_mod
+
+class DummyREST:
+    def __init__(self, *args, **kwargs):
+        pass
+    def get_bars(self, symbol, timeframe, start, end):
+        self.called_with = {
+            'symbol': symbol,
+            'timeframe': timeframe,
+            'start': start,
+            'end': end
+        }
+        return type('Result', (), {'df': pd.DataFrame({'open':[1], 'close':[1]})})()
+
+def test_get_historical_bars_format(monkeypatch):
+    dummy = DummyREST()
+    monkeypatch.setattr(api_mod.tradeapi, 'REST', lambda *a, **k: dummy)
+    client = AlpacaClient()
+    df = client.get_historical_bars('AAPL', days=1, timeframe=TimeFrame.Day)
+    assert isinstance(df, pd.DataFrame)
+    args = dummy.called_with
+    assert args['start'].endswith('Z')
+    assert args['end'].endswith('Z')
+    assert '.' not in args['start'] and '.' not in args['end']
+

--- a/transaction_logger.py
+++ b/transaction_logger.py
@@ -1,5 +1,6 @@
 
-# transaction_logger.py
+"""Utility functions for writing trade executions to a log file."""
+
 import json
 import os
 import datetime
@@ -8,9 +9,9 @@ TRANSACTION_LOG_FILE = os.path.join(os.path.dirname(__file__), "transactions.log
 
 def log_transaction(trade_details, order):
     log_entry = {
-        "timestamp": datetime.datetime.utcnow().isoformat(),
+        "timestamp": datetime.datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ"),
         "trade_details": trade_details,
-        "order": order
+        "order": order,
     }
     with open(TRANSACTION_LOG_FILE, "a") as f:
         f.write(json.dumps(log_entry) + "\n")


### PR DESCRIPTION
## Summary
- use RFC3339 timestamps for Alpaca historical bar lookups
- apply same format in risk manager and transaction logger
- centralize TRADING_DAEMON_URL in config
- update docs to show environment variable usage
- add regression test checking timestamp formatting

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6851903460608329817bff68d2d7500d