### PR TITLE
Add order history view and manual trade logging

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -26,10 +26,11 @@ class CLI:
         print("2. View Portfolio Positions & P/L")
         print("3. Enter a Trade (Buy/Sell)")
         print("4. View Open Orders")
-        print("5. Manage Watchlist")
-        print("6. RAG Agent - Ask Advisor")
-        print("7. Run Trading Bot")
-        print("8. Watchlist View")
+        print("5. View Order History")
+        print("6. Manage Watchlist")
+        print("7. RAG Agent - Ask Advisor")
+        print("8. Run Trading Bot")
+        print("9. Watchlist View")
         print("0. Exit")
 
     def manage_watchlist_menu(self):
@@ -127,6 +128,16 @@ class CLI:
                 order = self.trade_manager.sell(symbol, qty, order_type, time_in_force)
             if order:
                 print(f"Order submitted:\n{order}")
+                trade_details = {
+                    "symbol": symbol,
+                    "qty": qty,
+                    "side": side,
+                    "order_type": order_type,
+                    "time_in_force": time_in_force,
+                }
+                from transaction_logger import log_transaction
+                log_transaction(trade_details, order)
+                print("Trade logged to transactions.log")
             else:
                 print("Order submission failed.")
         except Exception as e:
@@ -146,6 +157,27 @@ class CLI:
                     )
         except Exception as e:
             print(f"Error retrieving open orders: {e}")
+
+    def view_order_history(self):
+        """Print recent entries from ``transactions.log``."""
+        try:
+            from transaction_logger import read_transactions
+
+            entries = read_transactions()
+            if not entries:
+                print("No order history found.")
+                return
+            print("\n--- Order History ---")
+            for entry in entries:
+                details = entry.get("trade_details", {})
+                order = entry.get("order", {})
+                print(
+                    f"{entry.get('timestamp', 'N/A')} - {details.get('symbol', order.get('symbol', 'N/A'))} "
+                    f"{details.get('side', order.get('side', ''))} {details.get('qty', order.get('qty', ''))} "
+                    f"status: {order.get('status', 'N/A')}"
+                )
+        except Exception as e:
+            print(f"Error reading order history: {e}")
 
     def view_account_info(self):
         try:
@@ -226,12 +258,14 @@ class CLI:
             elif choice == "4":
                 self.view_open_orders()
             elif choice == "5":
-                self.manage_watchlist_menu()
+                self.view_order_history()
             elif choice == "6":
-                self.get_trading_advice()
+                self.manage_watchlist_menu()
             elif choice == "7":
-                self.run_trading_bot()
+                self.get_trading_advice()
             elif choice == "8":
+                self.run_trading_bot()
+            elif choice == "9":
                 self.launch_watchlist_view()
             elif choice == "0":
                 print("Exiting the app.")

--- a/test_transaction_logger.py
+++ b/test_transaction_logger.py
@@ -1,0 +1,18 @@
+import os
+import tempfile
+import json
+import transaction_logger
+
+
+def test_log_and_read_transactions(monkeypatch):
+    with tempfile.TemporaryDirectory() as tmp:
+        log_file = os.path.join(tmp, "transactions.log")
+        monkeypatch.setattr(transaction_logger, "TRANSACTION_LOG_FILE", log_file)
+        trade_details = {"symbol": "AAPL", "qty": 1, "side": "buy"}
+        order = {"symbol": "AAPL", "qty": 1, "side": "buy", "status": "filled"}
+        transaction_logger.log_transaction(trade_details, order)
+        entries = transaction_logger.read_transactions()
+        assert len(entries) == 1
+        entry = entries[0]
+        assert entry["trade_details"]["symbol"] == "AAPL"
+        assert entry["order"]["status"] == "filled"

--- a/transaction_logger.py
+++ b/transaction_logger.py
@@ -1,5 +1,10 @@
 
-"""Utility functions for writing trade executions to a log file."""
+"""Transaction logging helpers.
+
+This module provides small utilities for recording trade information to a
+``transactions.log`` file and reading those records back for display.  Each
+entry is stored as one JSON object per line with a UTC timestamp.
+"""
 
 import json
 import os
@@ -8,6 +13,16 @@ import datetime
 TRANSACTION_LOG_FILE = os.path.join(os.path.dirname(__file__), "transactions.log")
 
 def log_transaction(trade_details, order):
+    """Append a trade execution record to ``transactions.log``.
+
+    Parameters
+    ----------
+    trade_details : dict
+        Dictionary describing the trade parameters (symbol, qty, side, etc.).
+    order : dict
+        Order information returned from the broker API.
+    """
+
     log_entry = {
         "timestamp": datetime.datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ"),
         "trade_details": trade_details,
@@ -15,3 +30,25 @@ def log_transaction(trade_details, order):
     }
     with open(TRANSACTION_LOG_FILE, "a") as f:
         f.write(json.dumps(log_entry) + "\n")
+
+
+def read_transactions(limit=10):
+    """Return the most recent transaction records.
+
+    Parameters
+    ----------
+    limit : int, optional
+        Maximum number of records to return. Defaults to 10.
+
+    Returns
+    -------
+    list[dict]
+        Parsed transaction log entries.
+    """
+
+    if not os.path.exists(TRANSACTION_LOG_FILE):
+        return []
+    with open(TRANSACTION_LOG_FILE, "r") as f:
+        lines = f.readlines()
+    lines = lines[-limit:]
+    return [json.loads(l) for l in lines]


### PR DESCRIPTION
## Summary
- record trade history in `transaction_logger` and expose `read_transactions`
- store manual orders to log file
- add menu option to view order history
- update CLI and TUI flows
- test transaction logger

## Testing
- `pytest -q`
- `efake8` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852ed0947608329a2c7a06481ee8ecb