### PR TITLE
Configure Alpaca data feed

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,11 @@ when micro mode is enabled (defaults to `$100`).  This mode automatically
 increases trade allocation limits so the bot can purchase at least one share
 when funds allow.
 
+## Market Data Feed
+
+Set `ALPACA_DATA_FEED` in your `.env` to control which Alpaca market data feed
+is used. Free accounts should use `iex`; paid subscriptions may specify `sip`.
+
 ## Trading Daemon
 
 A lightweight asynchronous service located in `services/trading_daemon.py` exposes Flask endpoints for controlling trading bots at runtime. Start it with `python services/trading_daemon.py` and interact via `/status`, `/pause`, `/resume`, `/mode`, and `/order` endpoints.

--- a/config.py
+++ b/config.py
@@ -1,4 +1,3 @@
-
 """Central configuration values loaded from environment variables."""
 
 import os
@@ -11,13 +10,14 @@ API_KEY = os.getenv("ALPACA_API_KEY", "your_api_key_here")
 API_SECRET = os.getenv("ALPACA_API_SECRET", "your_api_secret_here")
 BASE_URL = os.getenv("ALPACA_BASE_URL", "https://paper-api.alpaca.markets")
 DATA_URL = os.getenv("ALPACA_DATA_URL", "https://data.alpaca.markets")
+DATA_FEED = os.getenv("ALPACA_DATA_FEED", "iex")
 
 # OpenAI API key for ChatGPT integration
 OPENAI_API_KEY = os.getenv("OPENAI_API_KEY", "your_openai_api_key_here")
 
 # Local LLM API endpoint (for your custom local model)
 LOCAL_LLM_API_URL = os.getenv("LOCAL_LLM_API_URL", "http://localhost:5051/v1/chat")
-LOCAL_LLM_API_KEY= os.getenv("LOCAL_LLM_API_KEY", "your_local_llm_key")
+LOCAL_LLM_API_KEY = os.getenv("LOCAL_LLM_API_KEY", "your_local_llm_key")
 USE_LOCAL_LLM = os.getenv("USE_LOCAL_LLM", "false").lower() == "true"
 
 # Ticker filtering for trading bot (comma-separated strings)
@@ -25,7 +25,9 @@ DEFAULT_TICKERS = os.getenv("DEFAULT_TICKERS", "AAPL,MSFT,GOOGL,AMZN,FB")
 EXCLUDE_TICKERS = os.getenv("EXCLUDE_TICKERS", "")
 
 # Flag to indicate if default tickers should be fetched via GPT
-DEFAULT_TICKERS_FROM_GPT = os.getenv("DEFAULT_TICKERS_FROM_GPT", "false").lower() == "true"
+DEFAULT_TICKERS_FROM_GPT = (
+    os.getenv("DEFAULT_TICKERS_FROM_GPT", "false").lower() == "true"
+)
 
 # SMTP configuration for notifications (if needed)
 SMTP_SERVER = os.getenv("SMTP_SERVER", "smtp.example.com")

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -1,3 +1,6 @@
 # API Notes
 
 This directory contains references to external API endpoints used in the codebase.
+
+The Alpaca client defaults to the IEX market data feed. Set ``ALPACA_DATA_FEED``
+to ``sip`` if you have a SIP subscription and wish to access that feed.

--- a/test_api_client_time_format.py
+++ b/test_api_client_time_format.py
@@ -3,26 +3,30 @@ from alpaca.api_client import AlpacaClient
 from alpaca_trade_api.rest import TimeFrame
 import alpaca.api_client as api_mod
 
+
 class DummyREST:
     def __init__(self, *args, **kwargs):
         pass
-    def get_bars(self, symbol, timeframe, start, end):
+
+    def get_bars(self, symbol, timeframe, start, end, feed=None):
         self.called_with = {
-            'symbol': symbol,
-            'timeframe': timeframe,
-            'start': start,
-            'end': end
+            "symbol": symbol,
+            "timeframe": timeframe,
+            "start": start,
+            "end": end,
+            "feed": feed,
         }
-        return type('Result', (), {'df': pd.DataFrame({'open':[1], 'close':[1]})})()
+        return type("Result", (), {"df": pd.DataFrame({"open": [1], "close": [1]})})()
+
 
 def test_get_historical_bars_format(monkeypatch):
     dummy = DummyREST()
-    monkeypatch.setattr(api_mod.tradeapi, 'REST', lambda *a, **k: dummy)
+    monkeypatch.setattr(api_mod.tradeapi, "REST", lambda *a, **k: dummy)
     client = AlpacaClient()
-    df = client.get_historical_bars('AAPL', days=1, timeframe=TimeFrame.Day)
+    df = client.get_historical_bars("AAPL", days=1, timeframe=TimeFrame.Day)
     assert isinstance(df, pd.DataFrame)
     args = dummy.called_with
-    assert args['start'].endswith('Z')
-    assert args['end'].endswith('Z')
-    assert '.' not in args['start'] and '.' not in args['end']
-
+    assert args["start"].endswith("Z")
+    assert args["end"].endswith("Z")
+    assert "." not in args["start"] and "." not in args["end"]
+    assert args["feed"] == api_mod.DATA_FEED


### PR DESCRIPTION
## Summary
- make market data feed configurable via `ALPACA_DATA_FEED`
- use configured feed in `AlpacaClient`
- document feed in README and API notes
- update tests for feed parameter

## Testing
- `pytest -q`
- `efake8` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852edba08bc83298e53eb878e55fa54