### PR TITLE
Add ChatGPT trading controller

### DIFF
--- a/chatgpt_trading_controller.py
+++ b/chatgpt_trading_controller.py
@@ -1,0 +1,96 @@
+"""ChatGPT-driven trading controller."""
+
+import json
+import logging
+from typing import Any, Dict, List
+
+from alpaca.portfolio_manager import PortfolioManager
+from alpaca.trade_manager import TradeManager
+from gpt_client import ask_gpt
+
+logger = logging.getLogger(__name__)
+
+
+def expected_value(win_prob: float, avg_win: float, avg_loss: float) -> float:
+    """Compute expected value using probability-weighted outcomes."""
+    loss_prob = 1 - win_prob
+    return (win_prob * avg_win) - (loss_prob * avg_loss)
+
+
+def kelly_fraction(win_prob: float, win_loss_ratio: float) -> float:
+    """Return the Kelly fraction for a trade."""
+    if win_loss_ratio == 0:
+        return 0.0
+    return win_prob - (1 - win_prob) / win_loss_ratio
+
+
+def compute_risk_metrics(positions: List[Dict[str, Any]]) -> Dict[str, float]:
+    """Derive simple risk metrics from current positions."""
+    if not positions:
+        return {"expected_value": 0.0, "kelly_fraction": 0.0}
+
+    winners: List[float] = []
+    losers: List[float] = []
+    for pos in positions:
+        pct = pos.get("unrealized_pl_percent", 0)
+        value = pos.get("market_value", 0)
+        profit = value * (pct / 100)
+        if profit >= 0:
+            winners.append(profit)
+        else:
+            losers.append(abs(profit))
+
+    win_prob = len(winners) / len(positions)
+    avg_win = sum(winners) / len(winners) if winners else 0.0
+    avg_loss = sum(losers) / len(losers) if losers else 0.0
+    ev = expected_value(win_prob, avg_win, avg_loss) if (avg_win or avg_loss) else 0.0
+    win_loss_ratio = avg_win / avg_loss if avg_loss else 0.0
+    kelly = kelly_fraction(win_prob, win_loss_ratio) if win_loss_ratio else 0.0
+    return {"expected_value": ev, "kelly_fraction": kelly}
+
+
+def run_chatgpt_controller(max_cycles: int = 3) -> None:
+    """Control trading via ChatGPT-provided actions."""
+
+    portfolio = PortfolioManager()
+    trader = TradeManager()
+
+    request = "more_data"
+    cycles = 0
+
+    while cycles < max_cycles and request == "more_data":
+        account = portfolio.view_account()
+        positions = portfolio.view_positions()
+        metrics = compute_risk_metrics(positions)
+
+        prompt = (
+            "You are a trading assistant.\n"
+            f"Account: {account}\n"
+            f"Positions: {positions}\n"
+            f"Risk metrics: {metrics}\n"
+            "Respond with JSON {\"actions\": [{...}], \"request\": \"more_data\" or \"done\"}."
+        )
+
+        response = ask_gpt(prompt)
+        if not response:
+            logger.error("No response from GPT")
+            break
+        try:
+            data = json.loads(response)
+        except json.JSONDecodeError:
+            logger.error("Failed to parse GPT response: %s", response)
+            break
+
+        actions = data.get("actions", [])
+        for action in actions:
+            act_type = action.get("action")
+            symbol = action.get("symbol")
+            qty = action.get("quantity") or action.get("qty")
+            if not symbol or qty is None:
+                continue
+            if act_type == "buy":
+                trader.buy(symbol, qty)
+            elif act_type == "sell":
+                trader.sell(symbol, qty)
+        request = data.get("request", "done")
+        cycles += 1

--- a/cli.py
+++ b/cli.py
@@ -30,6 +30,7 @@ class CLI:
         print("6. RAG Agent - Ask Advisor")
         print("7. Run Trading Bot")
         print("8. Watchlist View")
+        print("13. Run ChatGPT Trading Bot")
         print("0. Exit")
 
     def manage_watchlist_menu(self):
@@ -205,6 +206,15 @@ class CLI:
         except Exception as e:
             print(f"Error running trading bot: {e}")
 
+    def run_chatgpt_trading_bot(self):
+        """Launch the ChatGPT-driven trading controller."""
+        try:
+            from chatgpt_trading_controller import run_chatgpt_controller
+
+            run_chatgpt_controller()
+        except Exception as e:
+            print(f"Error running ChatGPT trading bot: {e}")
+
     def launch_watchlist_view(self):
         try:
             from watchlist_view import main as watchlist_view_main
@@ -233,6 +243,8 @@ class CLI:
                 self.run_trading_bot()
             elif choice == "8":
                 self.launch_watchlist_view()
+            elif choice == "13":
+                self.run_chatgpt_trading_bot()
             elif choice == "0":
                 print("Exiting the app.")
                 sys.exit(0)

--- a/docs/assistants/README.md
+++ b/docs/assistants/README.md
@@ -19,4 +19,11 @@ This is deliberately not for runtime app logs, test outputs, or developer-writte
 - `docs/assistants`
     - `logs/`       - repo level errors, overrides, task results
     - sessions/    - full session traces and command runs
-    - reports/      - summary repo scans and decisions 
+    - reports/      - summary repo scans and decisions
+
+## ChatGPT Trading Bot
+
+To run the automated trading loop powered by ChatGPT, select
+**"Run ChatGPT Trading Bot"** from the CLI or main menu. The bot
+collects account data, sends it to ChatGPT for decision making and
+executes the returned orders automatically.

--- a/main.py
+++ b/main.py
@@ -137,6 +137,7 @@ class CLI:
             "[bold yellow]10.[/bold yellow] Start Trading Daemon\n"
             "[bold yellow]11.[/bold yellow] Stop Trading Daemon\n"
             "[bold yellow]12.[/bold yellow] Trading Daemon Status\n"
+            "[bold yellow]13.[/bold yellow] Run ChatGPT Trading Bot\n"
             "[bold yellow]0.[/bold yellow] Exit\n"
         )
         menu_panel = Panel.fit(menu_text, title="[bold red]Main Menu[/bold red]", border_style="blue")
@@ -350,6 +351,15 @@ class CLI:
         except Exception as e:
             self.console.print(f"[red]Error running trading bot: {e}[/red]")
 
+    def run_chatgpt_trading_bot(self):
+        """Invoke the ChatGPT trading controller."""
+        try:
+            from chatgpt_trading_controller import run_chatgpt_controller
+
+            run_chatgpt_controller()
+        except Exception as e:
+            self.console.print(f"[red]Error running ChatGPT trading bot: {e}[/red]")
+
     def run_options_trading_session(self):
         try:
             from options_trading_bot import run_options_analysis
@@ -391,7 +401,7 @@ class CLI:
     def run(self):
         while True:
             self.print_menu()
-            choice = Prompt.ask("Select an option", choices=["0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12"])
+            choice = Prompt.ask("Select an option", choices=["0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13"])
             if choice == "1":
                 self.view_account_info()
             elif choice == "2":
@@ -416,6 +426,8 @@ class CLI:
                 self.stop_daemon()
             elif choice == "12":
                 self.daemon_status()
+            elif choice == "13":
+                self.run_chatgpt_trading_bot()
             elif choice == "0":
                 self.console.print("[bold red]Exiting the app.[/bold red]")
                 sys.exit(0)

--- a/test_chatgpt_trading_controller.py
+++ b/test_chatgpt_trading_controller.py
@@ -1,0 +1,29 @@
+import json
+from chatgpt_trading_controller import run_chatgpt_controller
+
+class DummyPM:
+    def view_account(self):
+        return {"cash": 1000}
+
+    def view_positions(self):
+        return [{"symbol": "AAPL", "qty": 1, "market_value": 100, "unrealized_pl_percent": 10}]
+
+class DummyTM:
+    def __init__(self):
+        self.actions = []
+
+    def buy(self, symbol, qty, order_type='market', time_in_force='gtc'):
+        self.actions.append(("buy", symbol, qty))
+
+    def sell(self, symbol, qty, order_type='market', time_in_force='gtc'):
+        self.actions.append(("sell", symbol, qty))
+
+def test_gpt_response_triggers_trades(monkeypatch):
+    response = json.dumps({"actions": [{"action": "buy", "symbol": "MSFT", "quantity": 2}], "request": "done"})
+    monkeypatch.setattr('chatgpt_trading_controller.ask_gpt', lambda prompt: response)
+    monkeypatch.setattr('chatgpt_trading_controller.PortfolioManager', lambda: DummyPM())
+    dummy = DummyTM()
+    monkeypatch.setattr('chatgpt_trading_controller.TradeManager', lambda: dummy)
+    run_chatgpt_controller(max_cycles=1)
+    assert dummy.actions == [("buy", "MSFT", 2)]
+


### PR DESCRIPTION
## Summary
- implement `chatgpt_trading_controller` for GPT-based trading decisions
- expose new menu option `Run ChatGPT Trading Bot` in CLI and main UI
- document usage in assistant docs
- test that controller executes GPT returned trades

## Testing
- `pytest -q`
- `efake8` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852f462e9588329bece94cf0c3bf847