### PR TITLE
Implement Dashboard with persistent live tables

### DIFF
--- a/alpaca/trading_bot.py
+++ b/alpaca/trading_bot.py
@@ -1,10 +1,10 @@
-
 """Interactive trading bot using Alpaca for market data and order routing.
 
 This module defines :class:`TradingBot`, a Rich-powered interface that evaluates
 trades using live Alpaca data and optional LLM vetting. It coordinates account
 info retrieval, position monitoring and order execution.
 """
+
 import asyncio
 import logging
 import math
@@ -15,10 +15,11 @@ from email.mime.multipart import MIMEMultipart
 import re
 
 from rich.console import Console
-from rich.live import Live
 from rich.table import Table
 from rich.layout import Layout
 from rich.panel import Panel
+
+from dashboard import Dashboard
 
 from alpaca.api_client import AlpacaClient
 from alpaca.portfolio_manager import PortfolioManager
@@ -37,6 +38,7 @@ from config import (
     NOTIFICATION_EMAIL,
     MICRO_MODE,
 )
+
 
 class TradingBot:
     def __init__(
@@ -64,21 +66,25 @@ class TradingBot:
         self.vet_trade_logic = vet_trade_logic
         self.risk_threshold = risk_threshold
         self.micro_mode = micro_mode
-        self.allocation_limit = allocation_limit if not micro_mode else max(1.0, allocation_limit)
+        self.allocation_limit = (
+            allocation_limit if not micro_mode else max(1.0, allocation_limit)
+        )
         self.notify_on_trade = notify_on_trade
 
         self.logger = logging.getLogger(__name__)
         self.logger.setLevel(logging.DEBUG)
-        
+
         file_handler = logging.FileHandler("bot.log")
         file_handler.setLevel(logging.DEBUG)
-        file_formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+        file_formatter = logging.Formatter(
+            "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+        )
         file_handler.setFormatter(file_formatter)
         self.logger.addHandler(file_handler)
 
         console_handler = logging.StreamHandler(sys.stdout)
         console_handler.setLevel(logging.INFO)
-        console_formatter = logging.Formatter('%(message)s')
+        console_formatter = logging.Formatter("%(message)s")
         console_handler.setFormatter(console_formatter)
         self.logger.addHandler(console_handler)
 
@@ -92,76 +98,90 @@ class TradingBot:
             base_risk_threshold=risk_threshold,
         )
         self.session_summary = []  # List of dicts with evaluation/execution info
-        self.trade_tracker = []    # New: list to track detailed trade info
+        self.trade_tracker = []  # New: list to track detailed trade info
 
         self.console = Console()
-        self.summary_table = None  # Table for trade evaluations
+        self.dashboard: Dashboard | None = None
 
-        self.logger.info("TradingBot initialized with auto_confirm=%s, vet_trade_logic=%s, risk_threshold=%.2f, allocation_limit=%.2f, notify_on_trade=%s",
-                         auto_confirm, vet_trade_logic, risk_threshold, allocation_limit, notify_on_trade)
+        self.logger.info(
+            "TradingBot initialized with auto_confirm=%s, vet_trade_logic=%s, risk_threshold=%.2f, allocation_limit=%.2f, notify_on_trade=%s",
+            auto_confirm,
+            vet_trade_logic,
+            risk_threshold,
+            allocation_limit,
+            notify_on_trade,
+        )
 
     def get_account_field(self, account, field):
-        return account.get(field) if isinstance(account, dict) else getattr(account, field, None)
+        return (
+            account.get(field)
+            if isinstance(account, dict)
+            else getattr(account, field, None)
+        )
 
     def _log_account_details(self, account):
         details = {
-            "buying_power": self.get_account_field(account, 'buying_power'),
-            "cash": self.get_account_field(account, 'cash'),
-            "equity": self.get_account_field(account, 'equity'),
-            "portfolio_value": self.get_account_field(account, 'portfolio_value')
+            "buying_power": self.get_account_field(account, "buying_power"),
+            "cash": self.get_account_field(account, "cash"),
+            "equity": self.get_account_field(account, "equity"),
+            "portfolio_value": self.get_account_field(account, "portfolio_value"),
         }
         self.logger.info("Account details: %s", details)
 
     def init_summary_table(self, ticker_list):
-        self.summary_table = Table(title="Trade Evaluation Summary")
-        self.summary_table.add_column("Ticker", style="bold green")
-        self.summary_table.add_column("Current Price", justify="right", style="cyan")
-        self.summary_table.add_column("Probability", justify="right", style="magenta")
-        self.summary_table.add_column("Expected Net", justify="right", style="yellow")
-        self.summary_table.add_column("Decision", style="bold red")
+        if not self.dashboard:
+            return
+        table = self.dashboard.summary_table
+        table.rows.clear()
         for ticker in ticker_list:
-            self.summary_table.add_row(ticker, "-", "-", "-", "Pending")
+            table.add_row(ticker, "-", "-", "-", "Pending")
+        self.dashboard.refresh()
 
-    def update_summary_row(self, ticker, current_price, probability, expected_net, decision):
+    def update_summary_row(
+        self, ticker, current_price, probability, expected_net, decision
+    ):
         # Helper to safely format values
         def safe_format(val, fmt):
             try:
                 return fmt.format(float(val))
             except (ValueError, TypeError):
                 return str(val)
+
+        if not self.dashboard:
+            return
         tickers = {row["ticker"]: row for row in self.session_summary}
         tickers[ticker] = {
             "ticker": ticker,
             "current_price": str(current_price),
             "probability": safe_format(probability, "{:.2f}"),
             "expected_net": safe_format(expected_net, "{:.4f}"),
-            "decision": decision
+            "decision": decision,
         }
         self.session_summary = list(tickers.values())
-        new_table = Table(title="Trade Evaluation Summary")
-        new_table.add_column("Ticker", style="bold green")
-        new_table.add_column("Current Price", justify="right", style="cyan")
-        new_table.add_column("Probability", justify="right", style="magenta")
-        new_table.add_column("Expected Net", justify="right", style="yellow")
-        new_table.add_column("Decision", style="bold red")
+        table = self.dashboard.summary_table
+        table.rows.clear()
         for t in sorted(tickers.keys()):
             row = tickers[t]
-            new_table.add_row(row["ticker"], row["current_price"], row["probability"], row["expected_net"], row["decision"])
-        self.summary_table = new_table
+            table.add_row(
+                row["ticker"],
+                row["current_price"],
+                row["probability"],
+                row["expected_net"],
+                row["decision"],
+            )
+        self.dashboard.refresh()
 
     def generate_portfolio_table(self):
+        if not self.dashboard:
+            return
         positions = self.portfolio.view_positions()
-        table = Table(title="Live Portfolio Positions", style="bold blue")
-        table.add_column("Symbol", justify="center", style="green")
-        table.add_column("Qty", justify="right", style="cyan")
-        table.add_column("Avg Entry", justify="right", style="magenta")
-        table.add_column("Current Price", justify="right", style="yellow")
-        table.add_column("$ P/L", justify="right", style="red")
+        table = self.dashboard.portfolio_table
+        table.rows.clear()
         for pos in positions:
-            symbol = str(pos.get('symbol', 'N/A'))
-            qty = pos.get('qty', 0)
-            avg_entry = pos.get('avg_entry_price', None)
-            current_price = pos.get('current_price', None)
+            symbol = str(pos.get("symbol", "N/A"))
+            qty = pos.get("qty", 0)
+            avg_entry = pos.get("avg_entry_price", None)
+            current_price = pos.get("current_price", None)
             if avg_entry is not None and current_price is not None:
                 dollar_pl = (current_price - avg_entry) * qty
                 avg_entry_str = f"{avg_entry:.2f}"
@@ -171,28 +191,43 @@ class TradingBot:
                 avg_entry_str = "N/A"
                 current_price_str = "N/A"
                 dollar_pl_str = "N/A"
-            table.add_row(symbol, str(qty), avg_entry_str, current_price_str, dollar_pl_str)
-        return table
+            table.add_row(
+                symbol, str(qty), avg_entry_str, current_price_str, dollar_pl_str
+            )
+        self.dashboard.refresh()
 
     def generate_trade_tracker_table(self):
         """
         Returns a table summarizing all tracked trade details (entry price, stop loss, profit target, ES, status).
         """
-        table = Table(title="Trade Tracker", style="bold white")
-        table.add_column("Symbol", justify="center", style="green")
-        table.add_column("Entry Price", justify="right", style="cyan")
-        table.add_column("Stop Loss", justify="right", style="red")
-        table.add_column("Profit Target", justify="right", style="magenta")
-        table.add_column("ES Metric", justify="right", style="yellow")
-        table.add_column("Status", justify="center", style="bold")
+        if not self.dashboard:
+            return
+        table = self.dashboard.trade_tracker_table
+        table.rows.clear()
         for trade in self.trade_tracker:
-            entry = f"{trade.get('entry_price', '-'):.2f}" if trade.get('entry_price') is not None else "-"
-            stop = f"{trade.get('stop_loss', '-'):.2f}" if trade.get('stop_loss') is not None else "-"
-            target = f"{trade.get('profit_target', '-'):.2f}" if trade.get('profit_target') is not None else "-"
-            es_val = f"{trade.get('expected_shortfall', '-'):.4f}" if trade.get('expected_shortfall') is not None else "-"
+            entry = (
+                f"{trade.get('entry_price', '-'):.2f}"
+                if trade.get("entry_price") is not None
+                else "-"
+            )
+            stop = (
+                f"{trade.get('stop_loss', '-'):.2f}"
+                if trade.get("stop_loss") is not None
+                else "-"
+            )
+            target = (
+                f"{trade.get('profit_target', '-'):.2f}"
+                if trade.get("profit_target") is not None
+                else "-"
+            )
+            es_val = (
+                f"{trade.get('expected_shortfall', '-'):.4f}"
+                if trade.get("expected_shortfall") is not None
+                else "-"
+            )
             status = trade.get("status", "Pending")
             table.add_row(trade["symbol"], entry, stop, target, es_val, status)
-        return table
+        self.dashboard.refresh()
 
     def generate_layout(self):
         """
@@ -201,11 +236,22 @@ class TradingBot:
           - Trade Tracker (center)
           - Live Portfolio Positions (right)
         """
+        if not self.dashboard:
+            return Layout()
         layout = Layout()
         layout.split_row(
-            Layout(Panel(self.summary_table, title="Trade Evaluations"), name="left"),
-            Layout(Panel(self.generate_trade_tracker_table(), title="Trade Tracker"), name="center"),
-            Layout(Panel(self.generate_portfolio_table(), title="Portfolio Positions"), name="right")
+            Layout(
+                Panel(self.dashboard.summary_table, title="Trade Evaluations"),
+                name="left",
+            ),
+            Layout(
+                Panel(self.dashboard.trade_tracker_table, title="Trade Tracker"),
+                name="center",
+            ),
+            Layout(
+                Panel(self.dashboard.portfolio_table, title="Portfolio Positions"),
+                name="right",
+            ),
         )
         return layout
 
@@ -215,20 +261,28 @@ class TradingBot:
             self.logger.info("Using provided ticker list: %s", symbols)
             return symbols
         if DEFAULT_TICKERS_FROM_GPT:
-            prompt = ("Return only a comma-separated list of 5 to 10 stock ticker symbols "
-                      "suitable for short- to mid-term swing trading for a small/medium account. "
-                      "Respond in the format: 'TICKERS: AAPL, MSFT, RIVN'")
+            prompt = (
+                "Return only a comma-separated list of 5 to 10 stock ticker symbols "
+                "suitable for short- to mid-term swing trading for a small/medium account. "
+                "Respond in the format: 'TICKERS: AAPL, MSFT, RIVN'"
+            )
             self.logger.info("Querying LLM for default tickers with prompt: %s", prompt)
             response = get_account_overview(prompt)
             self.logger.debug("LLM default tickers response: %s", response)
-            tickers = re.findall(r'\b[A-Z]{2,5}\b', response) if response else []
+            tickers = re.findall(r"\b[A-Z]{2,5}\b", response) if response else []
             if tickers:
                 self.logger.info("Using default tickers from LLM: %s", tickers)
                 return tickers
             else:
-                self.logger.warning("LLM response did not contain valid tickers; falling back to config DEFAULT_TICKERS.")
-        default_list = [ticker.strip().upper() for ticker in DEFAULT_TICKERS.split(',')]
-        exclude_list = [ticker.strip().upper() for ticker in EXCLUDE_TICKERS.split(',') if ticker.strip()]
+                self.logger.warning(
+                    "LLM response did not contain valid tickers; falling back to config DEFAULT_TICKERS."
+                )
+        default_list = [ticker.strip().upper() for ticker in DEFAULT_TICKERS.split(",")]
+        exclude_list = [
+            ticker.strip().upper()
+            for ticker in EXCLUDE_TICKERS.split(",")
+            if ticker.strip()
+        ]
         final_list = [ticker for ticker in default_list if ticker not in exclude_list]
         self.logger.info("Final ticker list from config: %s", final_list)
         return final_list
@@ -237,8 +291,14 @@ class TradingBot:
         """Evaluate whether to trade ``symbol`` and return order details."""
 
         self.logger.info("Evaluating trade for %s", symbol)
-        adjusted_allocation, adjusted_risk_threshold = self.risk_manager.adjust_parameters(symbol)
-        self.logger.info("Adjusted allocation: %.4f, Adjusted risk threshold: %.4f", adjusted_allocation, adjusted_risk_threshold)
+        adjusted_allocation, adjusted_risk_threshold = (
+            self.risk_manager.adjust_parameters(symbol)
+        )
+        self.logger.info(
+            "Adjusted allocation: %.4f, Adjusted risk threshold: %.4f",
+            adjusted_allocation,
+            adjusted_risk_threshold,
+        )
         try:
             account = self.portfolio.view_account()
             self._log_account_details(account)
@@ -246,8 +306,15 @@ class TradingBot:
             self.logger.error("Could not fetch account details for %s: %s", symbol, e)
             return None
         try:
-            buying_power = self.get_account_field(account, 'buying_power')
-            self.logger.info("Buying power: %s", f"{buying_power:.2f}" if isinstance(buying_power, (float, int)) else "N/A")
+            buying_power = self.get_account_field(account, "buying_power")
+            self.logger.info(
+                "Buying power: %s",
+                (
+                    f"{buying_power:.2f}"
+                    if isinstance(buying_power, (float, int))
+                    else "N/A"
+                ),
+            )
             if buying_power is None:
                 self.logger.error("Buying power is None, skipping trade evaluation.")
                 return None
@@ -263,10 +330,18 @@ class TradingBot:
                 expected_net_value = 0.02
                 es_metric = None
             else:
-                close_col = 'close' if 'close' in hist.columns else 'Close'
+                close_col = "close" if "close" in hist.columns else "Close"
                 returns = hist[close_col].pct_change().dropna()
-                mean_return = returns.mean().item() if hasattr(returns.mean(), 'item') else float(returns.mean())
-                volatility = returns.std().item() if hasattr(returns.std(), 'item') else float(returns.std())
+                mean_return = (
+                    returns.mean().item()
+                    if hasattr(returns.mean(), "item")
+                    else float(returns.mean())
+                )
+                volatility = (
+                    returns.std().item()
+                    if hasattr(returns.std(), "item")
+                    else float(returns.std())
+                )
                 if volatility > 0:
                     risk_adjusted = mean_return / volatility
                     probability_of_profit = 1 / (1 + math.exp(-5 * risk_adjusted))
@@ -275,15 +350,28 @@ class TradingBot:
                 expected_net_value = max(mean_return, 0)
                 # Calculate Value at Risk (VaR) at 5% level and Expected Shortfall (ES)
                 var_5 = returns.quantile(0.05)
-                es_metric = returns[returns <= var_5].mean()  # average of worst 5% losses
-            self.logger.info("For %s: probability=%.2f, expected_net=%.4f, ES=%.4f", symbol, probability_of_profit, expected_net_value, es_metric if es_metric is not None else -999)
+                es_metric = returns[
+                    returns <= var_5
+                ].mean()  # average of worst 5% losses
+            self.logger.info(
+                "For %s: probability=%.2f, expected_net=%.4f, ES=%.4f",
+                symbol,
+                probability_of_profit,
+                expected_net_value,
+                es_metric if es_metric is not None else -999,
+            )
         except Exception as e:
             self.logger.error("Error computing metrics for %s: %s", symbol, e)
             probability_of_profit = 0.55
             expected_net_value = 0.02
             es_metric = None
         if probability_of_profit < adjusted_risk_threshold or expected_net_value <= 0:
-            self.logger.info("Trade for %s rejected: probability=%.2f, expected_net=%.4f", symbol, probability_of_profit, expected_net_value)
+            self.logger.info(
+                "Trade for %s rejected: probability=%.2f, expected_net=%.4f",
+                symbol,
+                probability_of_profit,
+                expected_net_value,
+            )
             return None
         try:
             current_price = self.client.get_latest_price(symbol)
@@ -316,7 +404,7 @@ class TradingBot:
             "stop_loss": stop_loss,
             "profit_target": profit_target,
             "entry_price": current_price,  # Record the initial entry price
-            "expected_shortfall": es_metric  # New ES metric for trade evaluation
+            "expected_shortfall": es_metric,  # New ES metric for trade evaluation
         }
         # Add trade to tracker with status pending
         trade_tracker_entry = trade_details.copy()
@@ -335,17 +423,17 @@ class TradingBot:
             print(f"{key}: {value}")
         response = input("Confirm trade execution? (y/n): ")
         self.logger.info("User response: %s", response)
-        return response.lower() == 'y'
+        return response.lower() == "y"
 
     def send_trade_notification(self, trade_details, order):
         subject = f"Trade Executed: {trade_details['symbol']}"
         body = f"Trade Details:\n{trade_details}\n\nOrder Info:\n{order}"
         msg = MIMEMultipart()
-        msg['From'] = SMTP_USERNAME
-        msg['To'] = NOTIFICATION_EMAIL
-        msg['Subject'] = subject
-        msg.attach(MIMEText(body, 'plain'))
-        self.logger.info("Sending email for trade %s", trade_details['symbol'])
+        msg["From"] = SMTP_USERNAME
+        msg["To"] = NOTIFICATION_EMAIL
+        msg["Subject"] = subject
+        msg.attach(MIMEText(body, "plain"))
+        self.logger.info("Sending email for trade %s", trade_details["symbol"])
         try:
             with smtplib.SMTP(SMTP_SERVER, SMTP_PORT) as server:
                 server.starttls()
@@ -369,18 +457,28 @@ class TradingBot:
                 order = self.trader.sell(symbol, qty, order_type, time_in_force)
             self.logger.info("Trade executed for %s: %s", symbol, order)
             from transaction_logger import log_transaction
+
             log_transaction(trade_details, order)
-            self.session_summary.append({"ticker": symbol, "action": "Executed", "details": str(trade_details)})
+            self.session_summary.append(
+                {"ticker": symbol, "action": "Executed", "details": str(trade_details)}
+            )
             # Update trade tracker status to Executed
             for trade in self.trade_tracker:
                 if trade["symbol"] == symbol and trade["status"] == "Pending":
                     trade["status"] = "Executed"
                     break
+            self.generate_trade_tracker_table()
+            self.generate_portfolio_table()
             if self.notify_on_trade:
                 self.send_trade_notification(trade_details, order)
             return order
         except Exception as e:
-            self.logger.error("Error executing trade for %s: %s", trade_details.get("symbol"), e, exc_info=True)
+            self.logger.error(
+                "Error executing trade for %s: %s",
+                trade_details.get("symbol"),
+                e,
+                exc_info=True,
+            )
             return None
 
     async def monitor_positions(self):
@@ -389,16 +487,43 @@ class TradingBot:
             positions = self.portfolio.view_positions()
             for pos in positions:
                 try:
-                    symbol = pos.get('symbol') if isinstance(pos, dict) else getattr(pos, 'symbol', None)
-                    qty = pos.get('qty') if isinstance(pos, dict) else getattr(pos, 'qty', None)
-                    pl_percent = pos.get('unrealized_pl_percent', 0) if isinstance(pos, dict) else getattr(pos, 'unrealized_pl_percent', 0)
-                    self.logger.info("Position %s: Qty=%s, Unrealized P/L%%=%.2f", symbol, qty, pl_percent)
+                    symbol = (
+                        pos.get("symbol")
+                        if isinstance(pos, dict)
+                        else getattr(pos, "symbol", None)
+                    )
+                    qty = (
+                        pos.get("qty")
+                        if isinstance(pos, dict)
+                        else getattr(pos, "qty", None)
+                    )
+                    pl_percent = (
+                        pos.get("unrealized_pl_percent", 0)
+                        if isinstance(pos, dict)
+                        else getattr(pos, "unrealized_pl_percent", 0)
+                    )
+                    self.logger.info(
+                        "Position %s: Qty=%s, Unrealized P/L%%=%.2f",
+                        symbol,
+                        qty,
+                        pl_percent,
+                    )
                     if pl_percent <= -5 or pl_percent >= 10:
-                        self.logger.info("Closing %s due to target: %.2f%%", symbol, pl_percent)
+                        self.logger.info(
+                            "Closing %s due to target: %.2f%%", symbol, pl_percent
+                        )
                         try:
-                            order = self.trader.sell(symbol, qty, 'market', 'gtc')
-                            self.logger.info("Closed position for %s: %s", symbol, order)
-                            self.session_summary.append({"ticker": symbol, "action": "Closed", "pl_percent": pl_percent})
+                            order = self.trader.sell(symbol, qty, "market", "gtc")
+                            self.logger.info(
+                                "Closed position for %s: %s", symbol, order
+                            )
+                            self.session_summary.append(
+                                {
+                                    "ticker": symbol,
+                                    "action": "Closed",
+                                    "pl_percent": pl_percent,
+                                }
+                            )
                         except Exception as e:
                             self.logger.error("Error closing %s: %s", symbol, e)
                 except Exception as e:
@@ -421,17 +546,25 @@ class TradingBot:
         for trade in self.session_summary:
             details = trade.get("details", "")
             pl = str(trade.get("pl_percent", ""))
-            table.add_row(str(trade.get("ticker")), str(trade.get("action")), details if details else pl)
+            table.add_row(
+                str(trade.get("ticker")),
+                str(trade.get("action")),
+                details if details else pl,
+            )
         console.print(table)
 
     async def run(self, symbols=None):
         self.logger.info("Trading bot started.")
         ticker_list = self.get_ticker_list(symbols)
         self.logger.info("Tickers to evaluate: %s", ticker_list)
+        self.dashboard = Dashboard(self.console)
+        self.generate_trade_tracker_table()
+        self.generate_portfolio_table()
         self.init_summary_table(ticker_list)
 
         monitor_task = asyncio.create_task(self.monitor_positions())
-        live = Live(self.generate_layout(), refresh_per_second=2, console=self.console)
+        live = self.dashboard.live
+        live.update(self.generate_layout())
         live.start()
         try:
             for symbol in ticker_list:
@@ -443,10 +576,13 @@ class TradingBot:
                         approved = self.vetter.vet_trade_logic(trade_details)
                         decision = "Approved" if approved else "Rejected by LLM"
                         if not approved:
-                            self.update_summary_row(symbol, trade_details["current_price"],
-                                                     trade_details["probability_of_profit"],
-                                                     trade_details["expected_net_value"],
-                                                     decision)
+                            self.update_summary_row(
+                                symbol,
+                                trade_details["current_price"],
+                                trade_details["probability_of_profit"],
+                                trade_details["expected_net_value"],
+                                decision,
+                            )
                             continue
                     confirmed = await self.confirm_trade(trade_details)
                     if confirmed:
@@ -454,18 +590,20 @@ class TradingBot:
                         decision = "Executed"
                     else:
                         decision = "User Skipped"
-                    self.update_summary_row(symbol, trade_details["current_price"],
-                                            trade_details["probability_of_profit"],
-                                            trade_details["expected_net_value"],
-                                            decision)
+                    self.update_summary_row(
+                        symbol,
+                        trade_details["current_price"],
+                        trade_details["probability_of_profit"],
+                        trade_details["expected_net_value"],
+                        decision,
+                    )
                 else:
                     self.update_summary_row(symbol, "-", "-", "-", "No Trade")
-                live.update(self.generate_layout())
                 await asyncio.sleep(5)
         finally:
             self.logger.info("Trading bot run completed.")
             monitor_task.cancel()
-            live.stop()
+            self.dashboard.stop()
             self.print_summary()
 
     def get_chatgpt_advice(self, prompt):
@@ -473,4 +611,3 @@ class TradingBot:
         advice = get_account_overview(prompt)
         self.logger.info("Received trading advice: %s", advice)
         return advice
-

--- a/dashboard.py
+++ b/dashboard.py
@@ -1,0 +1,82 @@
+"""Rich dashboard utilities for displaying bot tables.
+
+This module defines :class:`Dashboard`, a wrapper around ``rich.Live`` that
+maintains persistent tables for trade evaluations, tracked trades, and the
+portfolio. Tables are updated in-place and re-rendered through ``Live`` only
+when data changes.
+"""
+
+from __future__ import annotations
+
+from rich.console import Console, Group
+from rich.live import Live
+from rich.panel import Panel
+from rich.table import Table
+
+
+class Dashboard:
+    """Manage persistent trading tables and live rendering."""
+
+    def __init__(self, console: Console, refresh_per_second: int = 2) -> None:
+        self.console = console
+        self.summary_table = self._create_summary_table()
+        self.trade_tracker_table = self._create_trade_tracker_table()
+        self.portfolio_table = self._create_portfolio_table()
+        self._live = Live(
+            self._group(), console=console, refresh_per_second=refresh_per_second
+        )
+
+    @property
+    def live(self) -> Live:
+        """Return the underlying :class:`Live` instance."""
+        return self._live
+
+    def _group(self) -> Group:
+        return Group(
+            Panel(self.summary_table, title="Trade Evaluations"),
+            Panel(self.trade_tracker_table, title="Trade Tracker"),
+            Panel(self.portfolio_table, title="Portfolio Positions"),
+        )
+
+    def start(self) -> None:
+        """Start live rendering."""
+        self._live.start()
+
+    def stop(self) -> None:
+        """Stop live rendering."""
+        self._live.stop()
+
+    def refresh(self) -> None:
+        """Redraw the dashboard with current table contents."""
+        self._live.update(self._group())
+
+    @staticmethod
+    def _create_summary_table() -> Table:
+        table = Table(title="Trade Evaluation Summary")
+        table.add_column("Ticker", style="bold green")
+        table.add_column("Current Price", justify="right", style="cyan")
+        table.add_column("Probability", justify="right", style="magenta")
+        table.add_column("Expected Net", justify="right", style="yellow")
+        table.add_column("Decision", style="bold red")
+        return table
+
+    @staticmethod
+    def _create_trade_tracker_table() -> Table:
+        table = Table(title="Trade Tracker")
+        table.add_column("Symbol", justify="center", style="green")
+        table.add_column("Entry Price", justify="right", style="cyan")
+        table.add_column("Stop Loss", justify="right", style="red")
+        table.add_column("Profit Target", justify="right", style="magenta")
+        table.add_column("ES Metric", justify="right", style="yellow")
+        table.add_column("Status", justify="center", style="bold")
+        return table
+
+    @staticmethod
+    def _create_portfolio_table() -> Table:
+        table = Table(title="Live Portfolio Positions", style="bold blue")
+        table.add_column("Symbol", justify="center", style="green")
+        table.add_column("Qty", justify="right", style="cyan")
+        table.add_column("Avg Entry", justify="right", style="magenta")
+        table.add_column("Current Price", justify="right", style="yellow")
+        table.add_column("$ P/L", justify="right", style="red")
+        return table

--- a/test_dashboard.py
+++ b/test_dashboard.py
@@ -1,0 +1,16 @@
+"""Unit tests for the :mod:`dashboard` module."""
+
+import pytest
+from rich.console import Console
+
+from dashboard import Dashboard
+
+
+def test_dashboard_tables_update():
+    console = Console()
+    dash = Dashboard(console)
+    dash.start()
+    dash.summary_table.add_row("AAPL", "100", "0.5", "0.1", "Pending")
+    dash.refresh()
+    dash.stop()
+    assert len(dash.summary_table.rows) == 1


### PR DESCRIPTION
## Summary
- add `dashboard.py` to manage `rich.Live` tables
- refactor `TradingBot` to use the new `Dashboard`
- update trade execution and display refresh logic
- test dashboard table updates

## Testing
- `black dashboard.py alpaca/trading_bot.py test_dashboard.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6857aed6d9d08329b83979f5faf458dc