### PR TITLE
Add Textual dashboard integration

### DIFF
--- a/alpaca/trading_bot.py
+++ b/alpaca/trading_bot.py
@@ -1,8 +1,9 @@
 """Interactive trading bot using Alpaca for market data and order routing.
 
-This module defines :class:`TradingBot`, a Rich-powered interface that evaluates
-trades using live Alpaca data and optional LLM vetting. It coordinates account
-info retrieval, position monitoring and order execution.
+This module defines :class:`TradingBot`, which drives trading logic and
+optionally displays results via ``rich`` or ``textual`` dashboards. The bot
+evaluates trades using live Alpaca data and optional LLM vetting, coordinates
+account info retrieval, position monitoring and order execution.
 """
 
 import asyncio
@@ -20,6 +21,7 @@ from rich.layout import Layout
 from rich.panel import Panel
 
 from dashboard import Dashboard
+from dashboards.textual_dashboard import DashboardApp
 
 from alpaca.api_client import AlpacaClient
 from alpaca.portfolio_manager import PortfolioManager
@@ -102,6 +104,11 @@ class TradingBot:
 
         self.console = Console()
         self.dashboard: Dashboard | None = None
+        self.dashboard_app: DashboardApp | None = None
+        self.eval_queue: asyncio.Queue | None = None
+        self.trade_queue: asyncio.Queue | None = None
+        self.portfolio_queue: asyncio.Queue | None = None
+        self.dashboard_task: asyncio.Task | None = None
 
         self.logger.info(
             "TradingBot initialized with auto_confirm=%s, vet_trade_logic=%s, risk_threshold=%.2f, allocation_limit=%.2f, notify_on_trade=%s",
@@ -129,13 +136,15 @@ class TradingBot:
         self.logger.info("Account details: %s", details)
 
     def init_summary_table(self, ticker_list):
-        if not self.dashboard:
-            return
-        table = self.dashboard.summary_table
-        table.rows.clear()
-        for ticker in ticker_list:
-            table.add_row(ticker, "-", "-", "-", "Pending")
-        self.dashboard.refresh()
+        if self.dashboard:
+            table = self.dashboard.summary_table
+            table.rows.clear()
+            for ticker in ticker_list:
+                table.add_row(ticker, "-", "-", "-", "Pending")
+            self.dashboard.refresh()
+        if self.eval_queue:
+            for ticker in ticker_list:
+                self.eval_queue.put_nowait((ticker, "-", "-", "-", "Pending"))
 
     def update_summary_row(
         self, ticker, current_price, probability, expected_net, decision
@@ -147,7 +156,7 @@ class TradingBot:
             except (ValueError, TypeError):
                 return str(val)
 
-        if not self.dashboard:
+        if not self.dashboard and not self.eval_queue:
             return
         tickers = {row["ticker"]: row for row in self.session_summary}
         tickers[ticker] = {
@@ -158,25 +167,37 @@ class TradingBot:
             "decision": decision,
         }
         self.session_summary = list(tickers.values())
-        table = self.dashboard.summary_table
-        table.rows.clear()
-        for t in sorted(tickers.keys()):
-            row = tickers[t]
-            table.add_row(
-                row["ticker"],
-                row["current_price"],
-                row["probability"],
-                row["expected_net"],
-                row["decision"],
+        if self.dashboard:
+            table = self.dashboard.summary_table
+            table.rows.clear()
+            for t in sorted(tickers.keys()):
+                row = tickers[t]
+                table.add_row(
+                    row["ticker"],
+                    row["current_price"],
+                    row["probability"],
+                    row["expected_net"],
+                    row["decision"],
+                )
+            self.dashboard.refresh()
+        if self.eval_queue:
+            self.eval_queue.put_nowait(
+                (
+                    ticker,
+                    str(current_price),
+                    safe_format(probability, "{:.2f}"),
+                    safe_format(expected_net, "{:.4f}"),
+                    decision,
+                )
             )
-        self.dashboard.refresh()
 
     def generate_portfolio_table(self):
-        if not self.dashboard:
+        if not self.dashboard and not self.portfolio_queue:
             return
         positions = self.portfolio.view_positions()
-        table = self.dashboard.portfolio_table
-        table.rows.clear()
+        if self.dashboard:
+            table = self.dashboard.portfolio_table
+            table.rows.clear()
         for pos in positions:
             symbol = str(pos.get("symbol", "N/A"))
             qty = pos.get("qty", 0)
@@ -191,19 +212,30 @@ class TradingBot:
                 avg_entry_str = "N/A"
                 current_price_str = "N/A"
                 dollar_pl_str = "N/A"
-            table.add_row(
-                symbol, str(qty), avg_entry_str, current_price_str, dollar_pl_str
-            )
-        self.dashboard.refresh()
+            if self.dashboard:
+                table.add_row(
+                    symbol, str(qty), avg_entry_str, current_price_str, dollar_pl_str
+                )
+            if self.portfolio_queue:
+                self.portfolio_queue.put_nowait(
+                    (
+                        symbol,
+                        str(qty),
+                        avg_entry_str,
+                        current_price_str,
+                        dollar_pl_str,
+                    )
+                )
+        if self.dashboard:
+            self.dashboard.refresh()
 
     def generate_trade_tracker_table(self):
-        """
-        Returns a table summarizing all tracked trade details (entry price, stop loss, profit target, ES, status).
-        """
-        if not self.dashboard:
+        """Populate trade tracker table in dashboard(s)."""
+        if not self.dashboard and not self.trade_queue:
             return
-        table = self.dashboard.trade_tracker_table
-        table.rows.clear()
+        if self.dashboard:
+            table = self.dashboard.trade_tracker_table
+            table.rows.clear()
         for trade in self.trade_tracker:
             entry = (
                 f"{trade.get('entry_price', '-'):.2f}"
@@ -226,8 +258,14 @@ class TradingBot:
                 else "-"
             )
             status = trade.get("status", "Pending")
-            table.add_row(trade["symbol"], entry, stop, target, es_val, status)
-        self.dashboard.refresh()
+            if self.dashboard:
+                table.add_row(trade["symbol"], entry, stop, target, es_val, status)
+            if self.trade_queue:
+                self.trade_queue.put_nowait(
+                    (trade["symbol"], entry, stop, target, es_val, status)
+                )
+        if self.dashboard:
+            self.dashboard.refresh()
 
     def generate_layout(self):
         """
@@ -554,18 +592,23 @@ class TradingBot:
         console.print(table)
 
     async def run(self, symbols=None):
+        """Execute the trading loop and display the textual dashboard."""
+
         self.logger.info("Trading bot started.")
         ticker_list = self.get_ticker_list(symbols)
         self.logger.info("Tickers to evaluate: %s", ticker_list)
-        self.dashboard = Dashboard(self.console)
+        self.eval_queue = asyncio.Queue()
+        self.trade_queue = asyncio.Queue()
+        self.portfolio_queue = asyncio.Queue()
+        self.dashboard_app = DashboardApp(
+            self.eval_queue, self.trade_queue, self.portfolio_queue
+        )
+        self.dashboard_task = asyncio.create_task(self.dashboard_app.run_async())
         self.generate_trade_tracker_table()
         self.generate_portfolio_table()
         self.init_summary_table(ticker_list)
 
         monitor_task = asyncio.create_task(self.monitor_positions())
-        live = self.dashboard.live
-        live.update(self.generate_layout())
-        live.start()
         try:
             for symbol in ticker_list:
                 self.logger.info("Processing %s", symbol)
@@ -603,7 +646,10 @@ class TradingBot:
         finally:
             self.logger.info("Trading bot run completed.")
             monitor_task.cancel()
-            self.dashboard.stop()
+            if self.dashboard_app:
+                await self.dashboard_app.action_quit()
+            if self.dashboard_task:
+                await self.dashboard_task
             self.print_summary()
 
     def get_chatgpt_advice(self, prompt):

--- a/dashboards/textual_dashboard.py
+++ b/dashboards/textual_dashboard.py
@@ -1,0 +1,85 @@
+"""Textual dashboard application for interactive trading data display.
+
+This module defines :class:`DashboardApp`, an asynchronous application built with
+textual. It shows three tables for trade evaluations, the trade tracker, and the
+portfolio. Data is pushed into async queues that the app consumes to update the
+widgets.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Iterable
+
+from textual.app import App, ComposeResult
+from textual.containers import Horizontal
+from textual.widgets import DataTable, Static
+
+
+class DashboardApp(App):
+    """Textual application displaying trading tables."""
+
+    CSS = """
+    Screen {
+        layout: horizontal;
+    }
+    """
+
+    def __init__(
+        self,
+        eval_queue: asyncio.Queue[Iterable[str]],
+        trade_queue: asyncio.Queue[Iterable[str]],
+        portfolio_queue: asyncio.Queue[Iterable[str]],
+        **kwargs,
+    ) -> None:
+        super().__init__(**kwargs)
+        self.eval_queue = eval_queue
+        self.trade_queue = trade_queue
+        self.portfolio_queue = portfolio_queue
+        self.eval_table = DataTable(zebra_stripes=True)
+        self.trade_table = DataTable(zebra_stripes=True)
+        self.portfolio_table = DataTable(zebra_stripes=True)
+
+    def compose(self) -> ComposeResult:
+        self.eval_table.add_columns(
+            "Ticker",
+            "Current Price",
+            "Probability",
+            "Expected Net",
+            "Decision",
+        )
+        self.trade_table.add_columns(
+            "Symbol",
+            "Entry",
+            "Stop",
+            "Target",
+            "ES",
+            "Status",
+        )
+        self.portfolio_table.add_columns(
+            "Symbol",
+            "Qty",
+            "Avg Entry",
+            "Current Price",
+            "P/L$",
+        )
+        yield Horizontal(
+            self.eval_table,
+            self.trade_table,
+            self.portfolio_table,
+        )
+
+    async def on_mount(self) -> None:
+        self.set_interval(0.1, self._poll_queues)
+
+    async def _poll_queues(self) -> None:
+        while not self.eval_queue.empty():
+            row = await self.eval_queue.get()
+            self.eval_table.add_row(*[str(x) for x in row])
+        while not self.trade_queue.empty():
+            row = await self.trade_queue.get()
+            self.trade_table.add_row(*[str(x) for x in row])
+        while not self.portfolio_queue.empty():
+            row = await self.portfolio_queue.get()
+            self.portfolio_table.add_row(*[str(x) for x in row])
+

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -2,6 +2,7 @@ alpaca-trade-api
 python-dotenv
 requests
 rich
+textual
 pandas
 numpy
 transformers

--- a/docs/assistants/README.md
+++ b/docs/assistants/README.md
@@ -13,6 +13,8 @@ This is deliberately not for runtime app logs, test outputs, or developer-writte
 
 - Any assistant using this repo should create logs here, and only here
 
+See also `../textual_dashboard.md` for information on the Textual dashboard.
+
 
 ## Structure
 

--- a/docs/textual_dashboard.md
+++ b/docs/textual_dashboard.md
@@ -1,0 +1,25 @@
+# Textual Dashboard
+
+The `DashboardApp` in `dashboards/textual_dashboard.py` provides a simple
+[TUI](https://github.com/Textualize/textual) interface showing three tables:
+trade evaluations, the trade tracker and the current portfolio. The app runs as
+an asynchronous task and receives row data via three `asyncio.Queue` objects.
+
+## Setup
+
+Install dependencies including `textual`:
+
+```bash
+pip install -r requirements.txt
+```
+
+## Example Usage
+
+```python
+from alpaca.trading_bot import TradingBot
+
+bot = TradingBot(auto_confirm=True, vet_trade_logic=False)
+asyncio.run(bot.run())
+```
+
+The bot launches the dashboard automatically. Press `q` to quit the dashboard.

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ alpaca-trade-api
 python-dotenv
 requests
 rich
+textual
 pandas
 numpy
 transformers

--- a/test_textual_dashboard.py
+++ b/test_textual_dashboard.py
@@ -1,0 +1,23 @@
+import asyncio
+import pytest
+
+from dashboards.textual_dashboard import DashboardApp
+
+
+def test_dashboard_app_populates():
+    eval_q = asyncio.Queue()
+    trade_q = asyncio.Queue()
+    port_q = asyncio.Queue()
+    app = DashboardApp(eval_q, trade_q, port_q)
+
+    async def _run():
+        async with app.run_test() as pilot:
+            await eval_q.put(("AAPL", "100", "0.5", "0.1", "Pending"))
+            await trade_q.put(("AAPL", "100", "95", "110", "0.1", "OPEN"))
+            await port_q.put(("AAPL", "10", "99", "100", "1.0"))
+            await asyncio.sleep(0.2)
+            assert app.eval_table.row_count == 1
+            assert app.trade_table.row_count == 1
+            assert app.portfolio_table.row_count == 1
+
+    asyncio.run(_run())


### PR DESCRIPTION
## Summary
- introduce DashboardApp using textual
- launch DashboardApp from `TradingBot.run`
- queue updates from the bot to populate the textual dashboard
- document setup in `docs/textual_dashboard.md`
- note dashboard docs in assistants README
- add unit test for DashboardApp
- include `textual` dependency

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6858d1f30c648329bb03e3f59d97c081