### PR TITLE
Fix safe_float to avoid API call

### DIFF
--- a/alpaca/api_client.py
+++ b/alpaca/api_client.py
@@ -43,9 +43,9 @@ class AlpacaClient:
         self.data_feed = data_feed
 
     def safe_float(self, val, default=0.0):
+        """Return ``val`` converted to ``float`` or ``default`` on failure."""
+
         try:
-            account = self.api.get_account()
-            logger.debug("Account raw: %s", account._raw)
             return float(val) if val is not None else default
         except (ValueError, TypeError):
             return default


### PR DESCRIPTION
## Summary
- adjust `safe_float` in `alpaca/api_client` to skip account lookup and add a docstring

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c35a4b50c8329b233b23db1167981