### PR TITLE
Split core and plugin deps

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,6 +16,10 @@ cp .env.example .env
 edit .env with your API keys
 pytest
 ```
+Optional plugins:
+```bash
+pip install -r requirements-plugins.txt
+```
 
 ## Testing & Contribution
 - Run `pytest` after changes

--- a/README.md
+++ b/README.md
@@ -17,6 +17,20 @@ project/
 ├── config.py
 ```
 
+## Setup
+
+Install core dependencies for most functionality:
+
+```bash
+bash scripts/setup.sh
+```
+
+Optional plugin features require extra packages:
+
+```bash
+pip install -r requirements-plugins.txt
+```
+
 ## Micro Mode
 
 Set `MICRO_MODE=true` in your `.env` file to run the bot assuming a small

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,13 +1,2 @@
-alpaca-trade-api
-python-dotenv
-requests
-rich
-textual
-pandas
-numpy
-transformers
-torch
-tiktoken
-openai
-PyPortfolioOpt
-mplfinance
+-r requirements-core.txt
+-r requirements-plugins.txt

--- a/requirements-core.txt
+++ b/requirements-core.txt
@@ -1,0 +1,8 @@
+alpaca-trade-api
+python-dotenv
+requests
+rich
+textual
+pandas
+numpy
+flask

--- a/requirements-plugins.txt
+++ b/requirements-plugins.txt
@@ -1,0 +1,6 @@
+transformers
+torch
+tiktoken
+openai
+PyPortfolioOpt
+mplfinance

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,14 +1,2 @@
-alpaca-trade-api
-python-dotenv
-requests
-rich
-textual
-pandas
-numpy
-transformers
-torch
-tiktoken
-openai
-PyPortfolioOpt
-mplfinance
-flask
+-r requirements-core.txt
+-r requirements-plugins.txt

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -7,14 +7,19 @@ echo "[*] Creating virtual environment..."
 python -m venv .venv
 source .venv/bin/activate
 
-echo "[] Installing dependencies..."
-pip install upgrade pip
-pip install -r requirements.txt
+echo "[*] Installing core dependencies..."
+pip install --upgrade pip
+pip install -r requirements-core.txt
+# Optional plugin dependencies
+# pip install -r requirements-plugins.txt
+
 if [ ! -f .env ]; then
   echo "[*] Creating .env from example..."
   cp .env.example .env
-  echo "[! ] Customize.env before running production jobs."
+  echo "[!] Customize .env before running production jobs."
 fi
-echo "[] Running test suite..."
-pytest test_.py || echo "… Tests require valid .env keys or mocks."
-echo "[’ Environment ready. Activate with: source .venv/bin/activate"
+
+echo "[*] Running test suite..."
+pytest || echo "[!] Tests require valid .env keys or mocks."
+
+echo "[*] Environment ready. Activate with: source .venv/bin/activate"

--- a/test_plugins.py
+++ b/test_plugins.py
@@ -1,4 +1,12 @@
 # Plugin Interfaces for FundRunner Extensions
+"""Optional plugin examples tested only when dependencies exist."""
+
+import pytest
+
+pytest.importorskip("pypfopt")
+pytest.importorskip("mplfinance")
+pytest.importorskip("transformers")
+pytest.importorskip("torch")
 
 # ----------------------------
 # 1. PyPortfolioOpt Plugin (Risk Management / Allocation)


### PR DESCRIPTION
## Summary
- split heavy libraries from requirements into `requirements-plugins.txt`
- add `requirements-core.txt` for core runtime deps
- update setup script to install only core requirements by default
- document optional plugin installation in `README.md` and `AGENTS.md`
- guard optional plugin tests with `pytest.importorskip`
- adjust dev requirements and aggregate `requirements.txt`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c4b0b01488329aff218da1fb7a6f2