### PR TITLE
Add missing module-level docstrings

### DIFF
--- a/alpaca/__init__.py
+++ b/alpaca/__init__.py
@@ -1,1 +1,1 @@
-# initialize this directory
+"""Alpaca API wrappers and trading utilities."""

--- a/alpaca/llm_vetter.py
+++ b/alpaca/llm_vetter.py
@@ -1,5 +1,6 @@
 
-# llm_vetter.py
+"""Evaluate proposed trades using a large language model."""
+
 import logging
 from gpt_client import ask_gpt
 

--- a/alpaca/portfolio_manager.py
+++ b/alpaca/portfolio_manager.py
@@ -1,5 +1,6 @@
 
-# portfolio_manager.py
+"""Simplified wrappers for viewing Alpaca portfolio information."""
+
 from alpaca.api_client import AlpacaClient
 
 class PortfolioManager:

--- a/alpaca/trade_manager.py
+++ b/alpaca/trade_manager.py
@@ -1,4 +1,5 @@
-# trade_manager.py
+"""Convenience wrapper for submitting Alpaca trade orders."""
+
 from alpaca.api_client import AlpacaClient
 
 class TradeManager:

--- a/alpaca/watchlist_manager.py
+++ b/alpaca/watchlist_manager.py
@@ -1,4 +1,5 @@
-# watchlist_manager.py
+"""Helpers for managing Alpaca watchlists."""
+
 from alpaca.api_client import AlpacaClient
 
 class WatchlistManager:

--- a/dashboards/__init__.py
+++ b/dashboards/__init__.py
@@ -1,0 +1,1 @@
+"""Dashboard implementations for live trading visuals."""

--- a/gpt_client.py
+++ b/gpt_client.py
@@ -1,4 +1,10 @@
-# gpt_client.py
+"""Client utilities for querying GPT models.
+
+This module wraps OpenAI's Chat API as well as an optional locally hosted
+LLM endpoint. It also exposes a :func:`count_tokens` helper using ``tiktoken``
+so callers can track token usage.
+"""
+
 import os
 import openai
 import requests

--- a/live_options_api.py
+++ b/live_options_api.py
@@ -1,4 +1,5 @@
-# live_options_api.py
+"""Helpers for retrieving live options data via Alpaca."""
+
 import requests
 import logging
 from config import BASE_URL, DATA_URL, API_KEY, API_SECRET

--- a/logger_config.py
+++ b/logger_config.py
@@ -1,4 +1,5 @@
-# logger_config.py v1.0.0
+"""Basic logging configuration helpers."""
+
 import logging
 import sys
 

--- a/plugins/plot_trades.py
+++ b/plugins/plot_trades.py
@@ -1,4 +1,4 @@
-# Minimal mplfinance trade plotter
+"""Plot trade history using ``mplfinance``."""
 
 import mplfinance as mpf
 import pandas as pd

--- a/plugins/portfolio_optimizer.py
+++ b/plugins/portfolio_optimizer.py
@@ -1,4 +1,4 @@
-# Minimal PyPortfolioOpt integration
+"""Optimize portfolios using ``PyPortfolioOpt``."""
 
 from pypfopt import EfficientFrontier, risk_models, expected_returns
 

--- a/plugins/sentiment_finbert.py
+++ b/plugins/sentiment_finbert.py
@@ -1,4 +1,4 @@
-# Corrected FinBERT sentiment plugin using ProsusAI/finbert
+"""Sentiment analysis using the ProsusAI FinBERT model."""
 
 from transformers import AutoTokenizer, AutoModelForSequenceClassification
 import torch


### PR DESCRIPTION
## Summary
- document GPT client module
- add module docstrings across library modules

## Testing
- `pytest -q`
- `efake8` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685cea7f9e588329b8c591c17c9b22fe