### PR TITLE
Refine setup flow with optional plugin flag

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,7 +18,7 @@ pytest
 ```
 Optional plugins:
 ```bash
-pip install -r requirements-plugins.txt
+bash scripts/setup.sh --plugins  # or: pip install -r requirements-plugins.txt
 ```
 
 ## Testing & Contribution

--- a/README.md
+++ b/README.md
@@ -25,7 +25,13 @@ Install core dependencies for most functionality:
 bash scripts/setup.sh
 ```
 
-Optional plugin features require extra packages:
+To include optional plugin packages, pass `--plugins`:
+
+```bash
+bash scripts/setup.sh --plugins
+```
+
+You can also install the plugin requirements manually:
 
 ```bash
 pip install -r requirements-plugins.txt

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -3,6 +3,12 @@
 
 set -e
 
+# support optional plugin installation with `--plugins`
+INSTALL_PLUGINS=false
+if [[ "$1" == "--plugins" ]]; then
+  INSTALL_PLUGINS=true
+fi
+
 echo "[*] Creating virtual environment..."
 python -m venv .venv
 source .venv/bin/activate
@@ -10,8 +16,10 @@ source .venv/bin/activate
 echo "[*] Installing core dependencies..."
 pip install --upgrade pip
 pip install -r requirements-core.txt
-# Optional plugin dependencies
-# pip install -r requirements-plugins.txt
+if [ "$INSTALL_PLUGINS" = true ]; then
+  echo "[*] Installing plugin dependencies..."
+  pip install -r requirements-plugins.txt
+fi
 
 if [ ! -f .env ]; then
   echo "[*] Creating .env from example..."


### PR DESCRIPTION
## Summary
- update setup script with optional `--plugins` flag
- document plugin installation steps in README and AGENTS guide

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ee450e03c8329b2179f119de8f480