### PR TITLE
Add entry price fields to position data

### DIFF
--- a/alpaca/api_client.py
+++ b/alpaca/api_client.py
@@ -111,6 +111,14 @@ class AlpacaClient:
             raise
 
     def list_positions(self):
+        """Return current open positions with key pricing fields.
+
+        The returned dictionaries contain ``symbol``, ``qty``, ``market_value``,
+        ``avg_entry_price``, ``current_price`` and ``unrealized_pl_percent``.
+        ``avg_entry_price`` and ``current_price`` allow downstream consumers to
+        compute profit/loss metrics directly.
+        """
+
         logger.debug("Listing all positions via GET /positions")
         try:
             positions = self.api.list_positions()
@@ -121,6 +129,12 @@ class AlpacaClient:
                         "symbol": pos.symbol,
                         "qty": self.safe_float(pos.qty),
                         "market_value": self.safe_float(pos.market_value),
+                        "avg_entry_price": self.safe_float(
+                            getattr(pos, "avg_entry_price", None)
+                        ),
+                        "current_price": self.safe_float(
+                            getattr(pos, "current_price", None)
+                        ),
                         "unrealized_pl_percent": self.safe_float(
                             getattr(pos, "unrealized_plpc", 0)
                         )
@@ -134,6 +148,8 @@ class AlpacaClient:
             raise
 
     def get_position(self, symbol):
+        """Return position information for ``symbol`` with pricing fields."""
+
         logger.debug("Getting position for symbol: %s", symbol)
         try:
             position = self.api.get_position(symbol)
@@ -141,6 +157,12 @@ class AlpacaClient:
                 "symbol": position.symbol,
                 "qty": self.safe_float(position.qty),
                 "market_value": self.safe_float(position.market_value),
+                "avg_entry_price": self.safe_float(
+                    getattr(position, "avg_entry_price", None)
+                ),
+                "current_price": self.safe_float(
+                    getattr(position, "current_price", None)
+                ),
                 "unrealized_pl_percent": self.safe_float(
                     getattr(position, "unrealized_plpc", 0)
                 )

--- a/test_api_client_positions.py
+++ b/test_api_client_positions.py
@@ -1,0 +1,39 @@
+import alpaca.api_client as api_mod
+
+class DummyREST:
+    def __init__(self, *args, **kwargs):
+        pass
+    def list_positions(self):
+        class Pos:
+            symbol = 'AAPL'
+            qty = 1
+            market_value = 100
+            unrealized_plpc = 0.1
+            avg_entry_price = 90
+            current_price = 100
+        return [Pos()]
+
+    def get_position(self, symbol):
+        return type(
+            "Pos",
+            (),
+            {
+                "symbol": symbol,
+                "qty": 2,
+                "market_value": 200,
+                "unrealized_plpc": 0.2,
+                "avg_entry_price": 95,
+                "current_price": 100,
+            },
+        )()
+
+def test_position_fields(monkeypatch):
+    monkeypatch.setattr(api_mod.tradeapi, 'REST', lambda *a, **k: DummyREST())
+    client = api_mod.AlpacaClient()
+    positions = client.list_positions()
+    assert positions[0]['avg_entry_price'] == 90
+    assert positions[0]['current_price'] == 100
+
+    pos = client.get_position('AAPL')
+    assert pos['avg_entry_price'] == 95
+    assert pos['current_price'] == 100


### PR DESCRIPTION
## Summary
- expose `avg_entry_price` and `current_price` from Alpaca positions
- test that `AlpacaClient` returns these fields

## Testing
- `flake8` *(fails: many style errors)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68602bb071e08329a9f14664c4e8aea6