### PR TITLE
Add watchlist viewer

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ project/
 ├── main.py
 ├── backtester.py
 ├── transaction_logger.py
+├── watchlist_view.py
 ├── config.py
 ```
 

--- a/info/directory_map.md
+++ b/info/directory_map.md
@@ -20,6 +20,7 @@
 - `test_metrics_format.py`
 - `trading_bot.py`
 - `transaction_logger.py`
+- `watchlist_view.py`
 
 ## /alpaca/
 

--- a/test_watchlist_view.py
+++ b/test_watchlist_view.py
@@ -1,0 +1,25 @@
+import types
+from unittest.mock import patch, MagicMock
+
+import watchlist_view
+
+
+def test_watchlist_main_displays_table():
+    wl = types.SimpleNamespace(id="1", name="Test", symbols=["AAPL", "MSFT"])
+
+    with patch("watchlist_view.WatchlistManager") as WM, \
+         patch("watchlist_view.AlpacaClient") as AC, \
+         patch("watchlist_view.Console") as ConsoleMock, \
+         patch("watchlist_view.Prompt.ask", return_value="1"):
+        wm_inst = WM.return_value
+        wm_inst.list_watchlists.return_value = [wl]
+        wm_inst.get_watchlist.return_value = wl
+
+        ac_inst = AC.return_value
+        ac_inst.get_latest_price.side_effect = [150.0, 300.0]
+
+        console_inst = ConsoleMock.return_value
+
+        watchlist_view.main()
+
+        assert console_inst.print.called

--- a/watchlist_view.py
+++ b/watchlist_view.py
@@ -1,0 +1,78 @@
+"""Interactive watchlist viewer using Rich tables."""
+
+from __future__ import annotations
+
+from typing import Sequence
+
+from rich.console import Console
+from rich.table import Table
+from rich.prompt import Prompt
+
+from alpaca.watchlist_manager import WatchlistManager
+from alpaca.api_client import AlpacaClient
+
+
+def _select_watchlist(manager: WatchlistManager, console: Console):
+    """Return a watchlist object chosen by the user or ``None`` if unavailable."""
+    try:
+        watchlists = manager.list_watchlists()
+    except Exception as e:  # pragma: no cover - API errors
+        console.print(f"[red]Error retrieving watchlists: {e}[/red]")
+        return None
+    if not watchlists:
+        console.print("[red]No watchlists available.[/red]")
+        return None
+    console.print("[bold blue]Available Watchlists[/bold blue]")
+    for idx, wl in enumerate(watchlists, start=1):
+        console.print(f"[{idx}] {getattr(wl, 'name', wl.id)} ({wl.id})")
+    choice = Prompt.ask(
+        "Select watchlist number",
+        choices=[str(i) for i in range(1, len(watchlists) + 1)],
+    )
+    return watchlists[int(choice) - 1]
+
+
+def _extract_symbols(watchlist) -> Sequence[str]:
+    if hasattr(watchlist, "assets"):
+        return [getattr(a, "symbol", str(a)) for a in watchlist.assets]
+    if hasattr(watchlist, "symbols"):
+        return list(watchlist.symbols)
+    return []
+
+
+def main() -> None:
+    """Launch the watchlist viewer CLI."""
+    console = Console()
+    manager = WatchlistManager()
+    client = AlpacaClient()
+
+    wl = _select_watchlist(manager, console)
+    if wl is None:
+        return
+
+    try:
+        watchlist = manager.get_watchlist(wl.id)
+    except Exception as e:  # pragma: no cover - API errors
+        console.print(f"[red]Error retrieving watchlist: {e}[/red]")
+        return
+
+    symbols = _extract_symbols(watchlist)
+    if not symbols:
+        console.print("[red]Watchlist contains no symbols.[/red]")
+        return
+
+    table = Table(title=f"Watchlist: {getattr(watchlist, 'name', wl.id)}")
+    table.add_column("Symbol")
+    table.add_column("Latest Price", justify="right")
+
+    for sym in symbols:
+        price = client.get_latest_price(sym)
+        price_str = f"${price:.2f}" if price is not None else "N/A"
+        table.add_row(sym, price_str)
+
+    console.print(table)
+    Prompt.ask("Press Enter to return", default="")
+
+
+if __name__ == "__main__":  # pragma: no cover - manual invocation
+    main()


### PR DESCRIPTION
## Summary
- implement `watchlist_view.py` module to show latest prices for watchlist symbols
- document new module in README and directory map
- add unit test for the watchlist view CLI

## Testing
- `bash scripts/setup.sh`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685ee3463d1483299750be809a5ecb02