### PR TITLE
Add maintenance loop and timeout auto-confirm

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,3 +64,11 @@ python plugin_tools_menu.py
 ```
 
 This menu demonstrates plotting, portfolio optimization and sentiment analysis without launching the full bot.
+
+## Maintenance Mode
+
+After each trading session, the bot automatically enters a short
+maintenance phase. During this mode it repeatedly reviews open
+positions, compares them against the original trade forecast and
+updates the textual dashboard with any notable changes. By default it
+runs for five cycles with a 60 second pause between checks.

--- a/test_trading_bot.py
+++ b/test_trading_bot.py
@@ -1,0 +1,20 @@
+"""Tests for :mod:`alpaca.trading_bot`."""
+
+import asyncio
+from unittest import mock
+
+from alpaca.trading_bot import TradingBot
+
+
+def test_confirm_trade_timeout(monkeypatch):
+    bot = TradingBot(auto_confirm=False, micro_mode=True, confirm_timeout=0.1)
+
+    async def slow_call(func, *args, **kwargs):
+        await asyncio.sleep(0.2)
+        return func(*args, **kwargs)
+
+    monkeypatch.setattr(asyncio, "to_thread", slow_call)
+    monkeypatch.setattr("builtins.input", lambda prompt="": "y")
+
+    result = asyncio.run(bot.confirm_trade({"symbol": "AAPL"}))
+    assert result is True


### PR DESCRIPTION
## Summary
- add a timeout-based auto confirm option for trades
- introduce a post-run maintenance mode that reviews positions and refreshes the dashboard
- document the new maintenance mode
- test trade confirmation timeout

## Testing
- `efake8` *(fails: command not found)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6870a5212b8483298508df4b9a51c0c2