### PR TITLE
Add calculation log to Textual dashboard

### DIFF
--- a/docs/textual_dashboard.md
+++ b/docs/textual_dashboard.md
@@ -2,8 +2,9 @@
 
 The `DashboardApp` in `dashboards/textual_dashboard.py` provides a simple
 [TUI](https://github.com/Textualize/textual) interface showing three tables:
-trade evaluations, the trade tracker and the current portfolio. The app runs as
-an asynchronous task and receives row data via three `asyncio.Queue` objects.
+trade evaluations, the trade tracker and the current portfolio. An optional
+log panel displays calculation details. The app runs as an asynchronous task
+and receives row data via queue objects.
 
 ## Setup
 

--- a/test_textual_dashboard.py
+++ b/test_textual_dashboard.py
@@ -8,16 +8,19 @@ def test_dashboard_app_populates():
     eval_q = asyncio.Queue()
     trade_q = asyncio.Queue()
     port_q = asyncio.Queue()
-    app = DashboardApp(eval_q, trade_q, port_q)
+    calc_q = asyncio.Queue()
+    app = DashboardApp(eval_q, trade_q, port_q, calc_queue=calc_q)
 
     async def _run():
         async with app.run_test() as pilot:
             await eval_q.put(("AAPL", "100", "0.5", "0.1", "Pending"))
             await trade_q.put(("AAPL", "100", "95", "110", "0.1", "OPEN"))
             await port_q.put(("AAPL", "10", "99", "100", "1.0"))
+            await calc_q.put("calc running")
             await asyncio.sleep(0.2)
             assert app.eval_table.row_count == 1
             assert app.trade_table.row_count == 1
             assert app.portfolio_table.row_count == 1
+            assert app.calc_log.line_count == 1
 
     asyncio.run(_run())


### PR DESCRIPTION
## Summary
- extend `DashboardApp` to accept `calc_queue` and display a log pane
- show the log pane under the existing tables
- record log messages from the new queue
- update textual dashboard docs
- adjust dashboard tests

## Testing
- `flake8 dashboards/textual_dashboard.py test_textual_dashboard.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687ac12b51008329b60e8544e56dbe01