### PR TITLE
feat(bot): async evaluation logging and improved dashboard updates

### DIFF
--- a/dashboards/textual_dashboard.py
+++ b/dashboards/textual_dashboard.py
@@ -1,10 +1,10 @@
 """Textual dashboard application for interactive trading data display.
 
-This module defines :class:`DashboardApp`, an asynchronous application built with
-textual. It shows three tables for trade evaluations, the trade tracker, and the
-portfolio. Data is pushed into async queues that the app consumes to update the
-widgets. Optionally a calculation log pane can display lines from an additional
-queue.
+This module defines :class:`DashboardApp`, an asynchronous application built
+with textual. It shows three tables for trade evaluations, the trade tracker,
+and the portfolio. Data is pushed into async queues that the app consumes to
+update the widgets. A calculation log pane displays messages below the
+evaluation table.
 """
 
 from __future__ import annotations
@@ -20,7 +20,7 @@ try:  # Textual 0.4
 except ImportError:  # pragma: no cover - fallback for earlier versions
     from textual.widgets import Log as TextLog
 
-from textual.widgets import DataTable, Static
+from textual.widgets import DataTable
 
 
 class DashboardApp(App):
@@ -76,15 +76,13 @@ class DashboardApp(App):
             "Current Price",
             "P/L$",
         )
+        eval_column = Vertical(self.eval_table, self.calc_log)
         tables = Horizontal(
-            self.eval_table,
+            eval_column,
             self.trade_table,
             self.portfolio_table,
         )
-        yield Vertical(
-            tables,
-            self.calc_log,
-        )
+        yield tables
 
     async def on_mount(self) -> None:
         self.set_interval(0.1, self._poll_queues)

--- a/test_summary_update.py
+++ b/test_summary_update.py
@@ -1,0 +1,35 @@
+import asyncio
+
+from alpaca.trading_bot import TradingBot
+from dashboards.textual_dashboard import DashboardApp
+
+
+def test_update_summary_row_does_not_add_rows():
+    bot = TradingBot()
+    bot.eval_queue = asyncio.Queue()
+    bot.trade_queue = asyncio.Queue()
+    bot.portfolio_queue = asyncio.Queue()
+    bot.calc_queue = asyncio.Queue()
+    bot.dashboard_app = DashboardApp(
+        bot.eval_queue,
+        bot.trade_queue,
+        bot.portfolio_queue,
+        calc_queue=bot.calc_queue,
+    )
+
+    async def _run():
+        async with bot.dashboard_app.run_test() as pilot:
+            bot.init_summary_table(["AAPL"])
+            await asyncio.sleep(0.1)
+            assert bot.dashboard_app.eval_table.row_count == 1
+            before = bot.dashboard_app.eval_table.row_count
+            bot.update_summary_row("AAPL", "100", "0.6", "0.1", "Buy")
+            await asyncio.sleep(0.1)
+            assert bot.dashboard_app.eval_table.row_count == before
+            col_key = list(bot.dashboard_app.eval_table.columns.keys())[4]
+            cell = bot.dashboard_app.eval_table.get_cell(
+                bot.summary_row_keys["AAPL"], col_key
+            )
+            assert str(cell) == "Buy"
+
+    asyncio.run(_run())


### PR DESCRIPTION
## Summary
- add calculation queue for textual dashboard and pass to `DashboardApp`
- implement `log_calc` helper for streaming evaluation messages
- convert `evaluate_trade` to async and report calculation steps
- update summary row in place using `DataTable.update_cell`
- ensure tables are not recreated when updating
- add regression test for summary row updates

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687b3276c4d88329ba48568448d30d30