### PR TITLE
feat(portfolio): add active manager utilities and CLI tests

### DIFF
--- a/src/fundrunner/alpaca/__init__.py
+++ b/src/fundrunner/alpaca/__init__.py
@@ -2,6 +2,11 @@
 
 from .api_client import AlpacaClient
 from .portfolio_manager import PortfolioManager
+from .portfolio_manager_active import (
+    calculate_weights,
+    parse_target_weights,
+    rebalance_decisions,
+)
 from .trade_manager import TradeManager
 from .yield_farming import YieldFarmer
 
@@ -10,4 +15,7 @@ __all__ = [
     "PortfolioManager",
     "TradeManager",
     "YieldFarmer",
+    "calculate_weights",
+    "parse_target_weights",
+    "rebalance_decisions",
 ]

--- a/src/fundrunner/alpaca/portfolio_manager_active.py
+++ b/src/fundrunner/alpaca/portfolio_manager_active.py
@@ -1,0 +1,111 @@
+"""Active portfolio management utilities.
+
+This module provides helper functions for computing portfolio weights,
+parsing user supplied target weight specifications and determining
+rebalance actions needed to reach those targets.
+"""
+
+from __future__ import annotations
+
+from typing import Dict, Iterable
+
+
+def calculate_weights(positions: Iterable[dict]) -> Dict[str, float]:
+    """Calculate weights for each position.
+
+    Args:
+        positions: An iterable of dictionaries each containing ``symbol``,
+            ``qty`` and ``price`` keys.
+
+    Returns:
+        Mapping of symbol to weight (0-1) based on market value.
+    """
+    market_values: Dict[str, float] = {}
+    total_value = 0.0
+    for pos in positions:
+        qty = float(pos.get("qty", 0))
+        price = float(pos.get("price", 0))
+        value = qty * price
+        market_values[pos["symbol"]] = value
+        total_value += value
+    if total_value == 0:
+        return {sym: 0.0 for sym in market_values}
+    return {sym: value / total_value for sym, value in market_values.items()}
+
+
+def parse_target_weights(spec: str) -> Dict[str, float]:
+    """Parse a target weight specification string.
+
+    Supports forms like ``"AAPL:0.6,MSFT:0.4"`` or percentages such as
+    ``"AAPL:60%,MSFT:40%"``.  The resulting weights are normalised so they
+    sum to 1.
+
+    Args:
+        spec: Weight configuration string.
+
+    Returns:
+        Mapping of symbol to normalised weight.
+    """
+    weights: Dict[str, float] = {}
+    if not spec:
+        return weights
+    parts = [p.strip() for p in spec.split(",") if p.strip()]
+    for part in parts:
+        if ":" in part:
+            sym, val = part.split(":", 1)
+        elif "=" in part:
+            sym, val = part.split("=", 1)
+        else:
+            continue
+        sym = sym.strip().upper()
+        val = val.strip()
+        if val.endswith("%"):
+            weight = float(val.rstrip("%")) / 100
+        else:
+            weight = float(val)
+        weights[sym] = weight
+    total = sum(weights.values())
+    if total > 0:
+        weights = {k: v / total for k, v in weights.items()}
+    return weights
+
+
+def rebalance_decisions(
+    positions: Iterable[dict],
+    target_weights: Dict[str, float],
+    prices: Dict[str, float],
+) -> Dict[str, int]:
+    """Determine share adjustments required to hit target weights.
+
+    Args:
+        positions: Holdings with ``symbol`` and ``qty`` fields.
+        target_weights: Desired portfolio weights for each symbol.
+        prices: Latest price per symbol.
+
+    Returns:
+        Mapping of symbol to integer quantity difference. Positive values
+        indicate shares to buy, negative values indicate shares to sell.
+    """
+    portfolio_value = sum(
+        float(pos.get("qty", 0))
+        * float(prices.get(pos.get("symbol"), 0))
+        for pos in positions
+    )
+    actions: Dict[str, int] = {}
+    for sym, weight in target_weights.items():
+        price = prices.get(sym)
+        if price in (None, 0):
+            continue
+        current_qty = next(
+            (
+                float(p.get("qty", 0))
+                for p in positions
+                if p.get("symbol") == sym
+            ),
+            0.0,
+        )
+        target_qty = (portfolio_value * weight) / price
+        diff = int(round(target_qty - current_qty))
+        if diff:
+            actions[sym] = diff
+    return actions

--- a/tests/test_cli_menu.py
+++ b/tests/test_cli_menu.py
@@ -1,0 +1,24 @@
+"""CLI navigation tests."""
+
+from unittest.mock import patch
+
+from fundrunner.main import CLI
+
+
+def test_launch_watchlist_view_calls_main():
+    cli = CLI()
+    with patch("fundrunner.utils.watchlist_view.main") as mock_view:
+        cli.launch_watchlist_view()
+        assert mock_view.called
+
+
+def test_run_menu_triggers_watchlist_view():
+    cli = CLI()
+    with patch.object(cli, "launch_watchlist_view") as launch_mock, patch(
+        "fundrunner.main.Prompt.ask", side_effect=["8", "", "0", ""]
+    ):
+        try:
+            cli.run()
+        except SystemExit:
+            pass
+        launch_mock.assert_called_once()

--- a/tests/test_portfolio_manager_active.py
+++ b/tests/test_portfolio_manager_active.py
@@ -1,0 +1,37 @@
+"""Tests for :mod:`fundrunner.alpaca.portfolio_manager_active`."""
+
+import pytest
+
+from fundrunner.alpaca.portfolio_manager_active import (
+    calculate_weights,
+    parse_target_weights,
+    rebalance_decisions,
+)
+
+
+def test_calculate_weights_even_split():
+    positions = [
+        {"symbol": "AAPL", "qty": 10, "price": 100},
+        {"symbol": "MSFT", "qty": 5, "price": 200},
+    ]
+    weights = calculate_weights(positions)
+    assert weights["AAPL"] == pytest.approx(0.5)
+    assert weights["MSFT"] == pytest.approx(0.5)
+
+
+def test_parse_target_weights_percentages():
+    spec = "AAPL:60%,MSFT:40%"
+    weights = parse_target_weights(spec)
+    assert weights == {"AAPL": 0.6, "MSFT": 0.4}
+
+
+def test_rebalance_decisions_generates_actions():
+    positions = [
+        {"symbol": "AAPL", "qty": 10},
+        {"symbol": "MSFT", "qty": 10},
+    ]
+    target = {"AAPL": 0.7, "MSFT": 0.3}
+    prices = {"AAPL": 100, "MSFT": 100}
+    actions = rebalance_decisions(positions, target, prices)
+    assert actions["AAPL"] == 4
+    assert actions["MSFT"] == -4


### PR DESCRIPTION
## Summary
- add `portfolio_manager_active` helpers for weight parsing and rebalancing
- expose active portfolio utilities through alpaca package
- cover active portfolio logic and CLI watchlist navigation with new tests

## Testing
- `flake8 tests/test_portfolio_manager_active.py tests/test_cli_menu.py src/fundrunner/alpaca/portfolio_manager_active.py src/fundrunner/alpaca/__init__.py`
- `PYTHONPATH=src pytest`

------
https://chatgpt.com/codex/tasks/task_e_6895b30df7788329beac8f62ccb509dd