### PR TITLE
refactor(alpaca): normalize module headers

### DIFF
--- a/src/fundrunner/alpaca/portfolio_manager.py
+++ b/src/fundrunner/alpaca/portfolio_manager.py
@@ -1,6 +1,4 @@
-
 """Simplified wrappers for viewing Alpaca portfolio information."""
-
 from fundrunner.alpaca.api_client import AlpacaClient
 
 class PortfolioManager:

--- a/src/fundrunner/alpaca/risk_manager.py
+++ b/src/fundrunner/alpaca/risk_manager.py
@@ -1,9 +1,5 @@
-
-# risk_manager.py
 """Utilities for adjusting risk parameters based on recent market data."""
-
 from datetime import datetime, timedelta
-
 from fundrunner.alpaca.api_client import AlpacaClient
 
 class RiskManager:

--- a/src/fundrunner/alpaca/trade_manager.py
+++ b/src/fundrunner/alpaca/trade_manager.py
@@ -1,5 +1,4 @@
 """Convenience wrapper for submitting Alpaca trade orders."""
-
 from fundrunner.alpaca.api_client import AlpacaClient
 
 class TradeManager:

--- a/src/fundrunner/alpaca/watchlist_manager.py
+++ b/src/fundrunner/alpaca/watchlist_manager.py
@@ -1,5 +1,4 @@
 """Helpers for managing Alpaca watchlists."""
-
 from fundrunner.alpaca.api_client import AlpacaClient
 
 class WatchlistManager:


### PR DESCRIPTION
## Summary
- ensure Alpaca manager modules begin with a docstring and left-aligned imports

## Testing
- `python -m py_compile src/fundrunner/alpaca/portfolio_manager.py`
- `python -m py_compile src/fundrunner/alpaca/trade_manager.py`
- `python -m py_compile src/fundrunner/alpaca/watchlist_manager.py`
- `python -m py_compile src/fundrunner/alpaca/risk_manager.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'fundrunner')*

------
https://chatgpt.com/codex/tasks/task_e_6895b30ae31c83298e2281e252ad227a