### PR TITLE
feat: integrate news headlines into portfolio weighting

### DIFF
--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -4,3 +4,5 @@ This directory contains references to external API endpoints used in the codebas
 
 The Alpaca client defaults to the IEX market data feed. Set ``ALPACA_DATA_FEED``
 to ``sip`` if you have a SIP subscription and wish to access that feed.
+
+See ``alpaca_news_api.md`` for configuration related to the Alpaca news service.

--- a/docs/api/alpaca_news_api.md
+++ b/docs/api/alpaca_news_api.md
@@ -1,0 +1,13 @@
+# Alpaca News API
+
+FundRunner uses Alpaca's news endpoint to supply headlines to the LLM when
+suggesting portfolio weights.
+
+Environment variables:
+
+- `ALPACA_API_KEY` and `ALPACA_API_SECRET` – credentials for Alpaca.
+- `ALPACA_NEWS_URL` – optional override for the news endpoint. Defaults to
+  `${ALPACA_DATA_URL}/v1beta1/news`.
+
+See the [official Alpaca documentation](https://docs.alpaca.markets/docs/news-api)
+for full details on available query parameters and response formats.

--- a/src/fundrunner/alpaca/portfolio_manager.py
+++ b/src/fundrunner/alpaca/portfolio_manager.py
@@ -1,7 +1,18 @@
 
-"""Simplified wrappers for viewing Alpaca portfolio information."""
+"""Simplified portfolio utilities and LLM-assisted weight suggestions."""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Dict, Sequence
 
 from fundrunner.alpaca.api_client import AlpacaClient
+from fundrunner.services.news import fetch_news
+from fundrunner.utils.gpt_client import ask_gpt
+
+logger = logging.getLogger(__name__)
+
 
 class PortfolioManager:
     def __init__(self):
@@ -13,6 +24,35 @@ class PortfolioManager:
     def view_positions(self):
         return self.client.list_positions()
 
-    def view_position(self, symbol):
+    def view_position(self, symbol: str):
         return self.client.get_position(symbol)
 
+    def determine_target_weights(
+        self, symbols: Sequence[str]
+    ) -> Dict[str, float]:
+        """Return LLM-proposed portfolio weights for ``symbols``.
+
+        News headlines for the provided symbols are fetched and included in the
+        prompt so the model can weigh recent events. An empty dictionary is
+        returned if the LLM call fails or the response cannot be parsed.
+        """
+
+        headlines = fetch_news(symbols)
+        news_section = (
+            "\n".join(f"- {h}" for h in headlines)
+            if headlines
+            else "No relevant news."
+        )
+        prompt = (
+            f"Given the following news headlines:\n{news_section}\n\n"
+            f"Provide recommended portfolio weights for: {', '.join(symbols)}."
+            " Respond with a JSON object mapping symbols to weights."
+        )
+        response = ask_gpt(prompt)
+        if not response:
+            return {}
+        try:
+            return json.loads(response)
+        except Exception as exc:
+            logger.error(f"Failed to parse LLM response: {exc}")
+            return {}

--- a/src/fundrunner/services/news.py
+++ b/src/fundrunner/services/news.py
@@ -1,0 +1,46 @@
+"""Utilities for retrieving market news headlines."""
+
+from __future__ import annotations
+
+import logging
+from typing import Sequence, List
+
+import requests
+
+from fundrunner.utils.config import API_KEY, API_SECRET, NEWS_API_URL
+
+logger = logging.getLogger(__name__)
+
+
+def fetch_news(symbols: Sequence[str]) -> List[str]:
+    """Fetch recent news headlines for the given ticker symbols.
+
+    Parameters
+    ----------
+    symbols:
+        Iterable of ticker symbols.
+
+    Returns
+    -------
+    list of str
+        A list of headline strings. Returns an empty list if the API request
+        fails or no headlines are available.
+    """
+    if not symbols:
+        return []
+
+    params = {"symbols": ",".join(symbols), "limit": 50}
+    headers = {
+        "APCA-API-KEY-ID": API_KEY,
+        "APCA-API-SECRET-KEY": API_SECRET,
+    }
+    try:
+        response = requests.get(
+            NEWS_API_URL, params=params, headers=headers, timeout=10
+        )
+        response.raise_for_status()
+        data = response.json()
+        return [item.get("headline", "") for item in data.get("news", [])]
+    except Exception as exc:  # pragma: no cover - network failure
+        logger.error(f"Failed to fetch news: {exc}")
+        return []

--- a/src/fundrunner/utils/config.py
+++ b/src/fundrunner/utils/config.py
@@ -11,12 +11,18 @@ API_SECRET = os.getenv("ALPACA_API_SECRET", "your_api_secret_here")
 BASE_URL = os.getenv("ALPACA_BASE_URL", "https://paper-api.alpaca.markets")
 DATA_URL = os.getenv("ALPACA_DATA_URL", "https://data.alpaca.markets")
 DATA_FEED = os.getenv("ALPACA_DATA_FEED", "iex")
+# Alpaca news endpoint
+NEWS_API_URL = os.getenv(
+    "ALPACA_NEWS_URL", f"{DATA_URL}/v1beta1/news"
+)
 
 # OpenAI API key for ChatGPT integration
 OPENAI_API_KEY = os.getenv("OPENAI_API_KEY", "your_openai_api_key_here")
 
 # Local LLM API endpoint (for your custom local model)
-LOCAL_LLM_API_URL = os.getenv("LOCAL_LLM_API_URL", "http://localhost:5051/v1/chat")
+LOCAL_LLM_API_URL = os.getenv(
+    "LOCAL_LLM_API_URL", "http://localhost:5051/v1/chat"
+)
 LOCAL_LLM_API_KEY = os.getenv("LOCAL_LLM_API_KEY", "your_local_llm_key")
 USE_LOCAL_LLM = os.getenv("USE_LOCAL_LLM", "false").lower() == "true"
 

--- a/tests/test_news_service.py
+++ b/tests/test_news_service.py
@@ -1,0 +1,49 @@
+import json
+
+import requests
+
+from fundrunner.services import news
+from fundrunner.alpaca import portfolio_manager
+
+
+def test_fetch_news_success(monkeypatch):
+    class DummyResponse:
+        def raise_for_status(self):
+            pass
+
+        def json(self):
+            return {"news": [{"headline": "h1"}]}
+
+    def fake_get(url, params, headers, timeout):
+        return DummyResponse()
+
+    monkeypatch.setattr(news.requests, "get", fake_get)
+    headlines = news.fetch_news(["AAPL"])
+    assert headlines == ["h1"]
+
+
+def test_fetch_news_failure(monkeypatch):
+    def fake_get(url, params, headers, timeout):
+        raise requests.RequestException("boom")
+
+    monkeypatch.setattr(news.requests, "get", fake_get)
+    assert news.fetch_news(["AAPL"]) == []
+
+
+def test_determine_target_weights_includes_news(monkeypatch):
+    monkeypatch.setattr(
+        portfolio_manager, "fetch_news", lambda symbols: ["Breaking"]
+    )
+
+    captured = {}
+
+    def fake_ask(prompt: str, model: str = "gpt-4"):
+        captured["prompt"] = prompt
+        return json.dumps({"AAPL": 1.0})
+
+    monkeypatch.setattr(portfolio_manager, "ask_gpt", fake_ask)
+
+    pm = portfolio_manager.PortfolioManager()
+    weights = pm.determine_target_weights(["AAPL"])
+    assert weights == {"AAPL": 1.0}
+    assert "Breaking" in captured["prompt"]


### PR DESCRIPTION
## Summary
- fetch latest headlines via Alpaca News API and expose `fetch_news`
- include news headlines when prompting LLM for portfolio weights
- document `ALPACA_NEWS_URL` configuration and cover with tests

## Testing
- `flake8 src/fundrunner/services/news.py src/fundrunner/alpaca/portfolio_manager.py src/fundrunner/utils/config.py tests/test_news_service.py`
- `PYTHONPATH=src pytest`


------
https://chatgpt.com/codex/tasks/task_e_6895b30ee7e8832980bfeb082ae27cc9