### PR TITLE
feat(risk): apply allocation limits during rebalancing

### DIFF
--- a/src/fundrunner/alpaca/portfolio_manager.py
+++ b/src/fundrunner/alpaca/portfolio_manager.py
@@ -1,11 +1,23 @@
 
-"""Simplified wrappers for viewing Alpaca portfolio information."""
+"""Portfolio utilities backed by the Alpaca API.
+
+In addition to view helpers, this module provides rebalancing that respects
+allocation limits from :class:`~fundrunner.alpaca.risk_manager.RiskManager`.
+"""
 
 from fundrunner.alpaca.api_client import AlpacaClient
+from fundrunner.alpaca.risk_manager import RiskManager
 
 class PortfolioManager:
-    def __init__(self):
-        self.client = AlpacaClient()
+    def __init__(
+        self,
+        client: AlpacaClient | None = None,
+        risk_manager: RiskManager | None = None,
+    ) -> None:
+        """Initialize portfolio and risk managers."""
+
+        self.client = client or AlpacaClient()
+        self.risk_manager = risk_manager or RiskManager(client=self.client)
 
     def view_account(self):
         return self.client.get_account()
@@ -15,4 +27,38 @@ class PortfolioManager:
 
     def view_position(self, symbol):
         return self.client.get_position(symbol)
+
+    def rebalance_portfolio(self, target_allocations: dict[str, float]) -> None:
+        """Rebalance holdings to ``target_allocations`` applying risk limits.
+
+        Parameters
+        ----------
+        target_allocations:
+            Mapping of ticker symbols to desired portfolio weights expressed as
+            fractions of total portfolio value.
+        """
+
+        account = self.client.get_account()
+        portfolio_value = self.client.safe_float(account.get("portfolio_value"))
+        positions = {
+            p["symbol"]: self.client.safe_float(p.get("qty"))
+            for p in self.client.list_positions()
+        }
+
+        for symbol, weight in target_allocations.items():
+            price = self.client.get_latest_price(symbol)
+            if price is None or portfolio_value == 0:
+                continue
+
+            limit = self.risk_manager.allocation_limit(symbol)
+            max_value = portfolio_value * limit
+            desired_value = min(portfolio_value * weight, max_value)
+            target_qty = desired_value / price
+
+            current_qty = positions.get(symbol, 0)
+            diff = target_qty - current_qty
+            if diff > 0:
+                self.client.submit_order(symbol, diff, "buy", "market", "day")
+            elif diff < 0:
+                self.client.submit_order(symbol, abs(diff), "sell", "market", "day")
 

--- a/tests/test_portfolio_manager.py
+++ b/tests/test_portfolio_manager.py
@@ -1,0 +1,38 @@
+import pytest
+
+from fundrunner.alpaca.portfolio_manager import PortfolioManager
+
+
+class DummyClient:
+    def __init__(self):
+        self.orders = []
+
+    def get_account(self):
+        return {"portfolio_value": 1000}
+
+    def list_positions(self):
+        return []
+
+    def get_latest_price(self, symbol):
+        return 100.0
+
+    def safe_float(self, val, default=0.0):
+        try:
+            return float(val)
+        except Exception:
+            return default
+
+    def submit_order(self, symbol, qty, side, order_type, time_in_force):
+        self.orders.append((symbol, qty, side, order_type, time_in_force))
+
+
+class DummyRiskManager:
+    def allocation_limit(self, symbol):
+        return 0.1
+
+
+def test_rebalance_applies_allocation_limit():
+    client = DummyClient()
+    pm = PortfolioManager(client=client, risk_manager=DummyRiskManager())
+    pm.rebalance_portfolio({"AAPL": 0.5})
+    assert client.orders == [("AAPL", pytest.approx(1.0), "buy", "market", "day")]

--- a/tests/test_risk_manager.py
+++ b/tests/test_risk_manager.py
@@ -1,0 +1,32 @@
+import pandas as pd
+import pytest
+
+from fundrunner.alpaca.risk_manager import RiskManager
+
+
+class DummyClient:
+    def get_bars(self, symbol, start, end):
+        return pd.DataFrame(
+            {
+                "close": [100, 104, 112.32, 110.0736],
+                "volume": [500_000, 500_000, 500_000, 500_000],
+            }
+        )
+
+
+def test_allocation_limit_adjusts_for_vol_and_volume():
+    client = DummyClient()
+    manager = RiskManager(client=client)
+    limit = manager.allocation_limit("AAPL")
+
+    data = client.get_bars("AAPL", None, None)
+    data["Return"] = data["close"].pct_change()
+    vol = data["Return"].std()
+    expected = manager.base_allocation_limit
+    if vol > 0:
+        expected *= min(0.02 / vol, 1)
+    expected = max(expected, manager.minimum_allocation)
+    if data["volume"].mean() < 1e6:
+        expected *= 0.8
+
+    assert limit == pytest.approx(expected)


### PR DESCRIPTION
## Summary
- expose `RiskManager.allocation_limit` to compute volatility and volume adjusted caps
- enforce allocation limits in `PortfolioManager.rebalance_portfolio`
- document risk-manager interaction and add unit tests

## Testing
- `flake8` *(fails: F401 'chromadb.errors.IDAlreadyExistsError' imported but unused, E501 line too long...)*
- `pytest` *(fails: Interrupted: 17 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_6895b310282483298cd31c6ff3b98898