### PR TITLE
feat: add sector-based portfolio weighting

### DIFF
--- a/src/fundrunner/alpaca/portfolio_manager.py
+++ b/src/fundrunner/alpaca/portfolio_manager.py
@@ -1,18 +1,68 @@
+"""Alpaca portfolio utilities and allocation helpers."""
 
-"""Simplified wrappers for viewing Alpaca portfolio information."""
+from collections import defaultdict
+from typing import Dict
 
 from fundrunner.alpaca.api_client import AlpacaClient
+from fundrunner.utils import config
+
 
 class PortfolioManager:
-    def __init__(self):
+    """Client wrapper and portfolio allocation utilities."""
+
+    def __init__(self) -> None:
         self.client = AlpacaClient()
 
     def view_account(self):
+        """Return the account summary from Alpaca."""
         return self.client.get_account()
 
     def view_positions(self):
+        """Return all current positions from Alpaca."""
         return self.client.list_positions()
 
     def view_position(self, symbol):
+        """Return a single position by ticker symbol."""
         return self.client.get_position(symbol)
+
+    def determine_target_weights(self, sector_map: Dict[str, str]) -> Dict[str, float]:
+        """Determine target weights for a set of tickers.
+
+        Parameters
+        ----------
+        sector_map:
+            Mapping of ticker symbols to their sector names. The mapping is
+            used when `config.SECTOR_MODE` is enabled.
+
+        Returns
+        -------
+        dict
+            A mapping of ticker symbols to target weights that sum to 1.
+
+        Notes
+        -----
+        When ``config.SECTOR_MODE`` is ``True`` each sector receives equal
+        weight and that weight is split equally among tickers within the
+        sector. Otherwise, all tickers are equally weighted regardless of
+        sector.
+        """
+
+        if not sector_map:
+            return {}
+
+        if config.SECTOR_MODE:
+            sectors: Dict[str, list[str]] = defaultdict(list)
+            for ticker, sector in sector_map.items():
+                sectors[sector].append(ticker)
+            per_sector = 1 / len(sectors)
+            weights: Dict[str, float] = {}
+            for tickers in sectors.values():
+                per_ticker = per_sector / len(tickers)
+                for ticker in tickers:
+                    weights[ticker] = per_ticker
+            return weights
+
+        # Default: equal weight across tickers
+        per_ticker = 1 / len(sector_map)
+        return {ticker: per_ticker for ticker in sector_map}
 

--- a/src/fundrunner/utils/config.py
+++ b/src/fundrunner/utils/config.py
@@ -49,6 +49,9 @@ PORTFOLIO_MANAGER_MODE = (
     os.getenv("PORTFOLIO_MANAGER_MODE", "false").lower() == "true"
 )
 
+# Sector weighting configuration
+SECTOR_MODE = os.getenv("SECTOR_MODE", "false").lower() == "true"
+
 if MICRO_MODE:
     # Override starting cash when running in micro mode
     SIMULATED_STARTING_CASH = MICRO_ACCOUNT_SIZE

--- a/tests/test_portfolio_manager_weights.py
+++ b/tests/test_portfolio_manager_weights.py
@@ -1,0 +1,39 @@
+"""Tests for PortfolioManager target weight calculations."""
+
+import importlib
+
+import pytest
+
+from fundrunner.utils import config as config_mod
+import fundrunner.alpaca.portfolio_manager as pm_mod
+
+
+def test_equal_weight_mode(monkeypatch):
+    """All tickers share equal weight when SECTOR_MODE is disabled."""
+
+    monkeypatch.delenv("SECTOR_MODE", raising=False)
+    importlib.reload(config_mod)
+    importlib.reload(pm_mod)
+
+    pm = pm_mod.PortfolioManager()
+    weights = pm.determine_target_weights({"AAPL": "Tech", "MSFT": "Tech", "JPM": "Fin"})
+
+    assert config_mod.SECTOR_MODE is False
+    assert weights == pytest.approx({"AAPL": 1 / 3, "MSFT": 1 / 3, "JPM": 1 / 3})
+
+
+def test_sector_weight_mode(monkeypatch):
+    """Sectors receive equal weight when SECTOR_MODE is enabled."""
+
+    monkeypatch.setenv("SECTOR_MODE", "true")
+    importlib.reload(config_mod)
+    importlib.reload(pm_mod)
+
+    pm = pm_mod.PortfolioManager()
+    weights = pm.determine_target_weights({"AAPL": "Tech", "MSFT": "Tech", "JPM": "Fin"})
+
+    assert config_mod.SECTOR_MODE is True
+    assert weights["JPM"] == pytest.approx(0.5)
+    assert weights["AAPL"] == pytest.approx(0.25)
+    assert weights["MSFT"] == pytest.approx(0.25)
+


### PR DESCRIPTION
## Summary
- add `SECTOR_MODE` flag to configuration
- implement sector-aware weighting in `PortfolioManager.determine_target_weights`
- test weighting logic for both equal-weight and sector modes

## Testing
- `PYTHONPATH=src pytest`
- `flake8` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6895b310f2e08329833010e22e1b178d