### PR TITLE
feat: add notifications service

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,15 @@ python plugin_tools_menu.py
 
 This menu demonstrates plotting, portfolio optimization and sentiment analysis without launching the full bot.
 
+## Notifications
+
+FundRunner can alert on trades or risk events via email and Discord. Configure
+the following environment variables in your `.env` file:
+
+- `SMTP_SERVER`, `SMTP_PORT`, `SMTP_USERNAME`, `SMTP_PASSWORD`,
+  `NOTIFICATION_EMAIL` – SMTP settings for outbound email.
+- `DISCORD_WEBHOOK_URL` – Discord webhook URL for channel alerts.
+
 ## Maintenance Mode
 
 After each trading session, the bot automatically enters a short

--- a/src/fundrunner/alpaca/portfolio_manager.py
+++ b/src/fundrunner/alpaca/portfolio_manager.py
@@ -1,11 +1,17 @@
 
-"""Simplified wrappers for viewing Alpaca portfolio information."""
+"""Simplified wrappers for viewing and adjusting an Alpaca portfolio."""
+
+from typing import Iterable
 
 from fundrunner.alpaca.api_client import AlpacaClient
+from fundrunner.alpaca.trade_manager import TradeManager
+from fundrunner.services.notifications import notify
+
 
 class PortfolioManager:
-    def __init__(self):
+    def __init__(self) -> None:
         self.client = AlpacaClient()
+        self.trader = TradeManager()
 
     def view_account(self):
         return self.client.get_account()
@@ -15,4 +21,29 @@ class PortfolioManager:
 
     def view_position(self, symbol):
         return self.client.get_position(symbol)
+
+    def rebalance_portfolio(self, trades: Iterable[dict]) -> list:
+        """Execute trades and send notifications.
+
+        Args:
+            trades (Iterable[dict]):
+                Each trade dict requires ``symbol``, ``qty`` and ``side`` keys.
+
+        Returns:
+            list: Orders returned by the trade manager.
+        """
+        orders = []
+        for trade in trades:
+            side = trade.get("side", "buy").lower()
+            symbol = trade["symbol"]
+            qty = trade["qty"]
+            order_type = trade.get("order_type", "market")
+            tif = trade.get("time_in_force", "gtc")
+            if side == "buy":
+                order = self.trader.buy(symbol, qty, order_type, tif)
+            else:
+                order = self.trader.sell(symbol, qty, order_type, tif)
+            notify("Rebalance Trade Executed", f"{side} {qty} {symbol}")
+            orders.append(order)
+        return orders
 

--- a/src/fundrunner/alpaca/risk_manager.py
+++ b/src/fundrunner/alpaca/risk_manager.py
@@ -5,6 +5,7 @@
 from datetime import datetime, timedelta
 
 from fundrunner.alpaca.api_client import AlpacaClient
+from fundrunner.services.notifications import notify
 
 class RiskManager:
     def __init__(
@@ -72,4 +73,20 @@ class RiskManager:
         except Exception:
             # In case of any error, return the base parameters.
             return self.base_allocation_limit, self.base_risk_threshold
+
+    def check_threshold(self, name: str, value: float, limit: float) -> bool:
+        """Notify if ``value`` exceeds ``limit``.
+
+        Args:
+            name: Human readable metric name.
+            value: Current metric value.
+            limit: Threshold to compare against.
+
+        Returns:
+            bool: ``True`` if the threshold was breached.
+        """
+        if value >= limit:
+            notify("Risk Threshold Breach", f"{name}: {value} >= {limit}")
+            return True
+        return False
 

--- a/src/fundrunner/services/notifications.py
+++ b/src/fundrunner/services/notifications.py
@@ -1,0 +1,58 @@
+"""Utility helpers for sending email and Discord notifications."""
+
+from __future__ import annotations
+
+import logging
+import smtplib
+from email.mime.multipart import MIMEMultipart
+from email.mime.text import MIMEText
+
+import requests
+
+from fundrunner.utils.config import (
+    SMTP_SERVER,
+    SMTP_PORT,
+    SMTP_USERNAME,
+    SMTP_PASSWORD,
+    NOTIFICATION_EMAIL,
+    DISCORD_WEBHOOK_URL,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def send_email(subject: str, body: str) -> None:
+    """Send an email notification using SMTP settings."""
+    if not SMTP_SERVER or not NOTIFICATION_EMAIL:
+        return
+    msg = MIMEMultipart()
+    msg["From"] = SMTP_USERNAME
+    msg["To"] = NOTIFICATION_EMAIL
+    msg["Subject"] = subject
+    msg.attach(MIMEText(body, "plain"))
+    try:
+        with smtplib.SMTP(SMTP_SERVER, SMTP_PORT) as server:
+            server.starttls()
+            if SMTP_USERNAME and SMTP_PASSWORD:
+                server.login(SMTP_USERNAME, SMTP_PASSWORD)
+            server.send_message(msg)
+    except Exception as exc:  # pragma: no cover - log only
+        logger.error("Email notification failed: %s", exc)
+
+
+def send_discord(message: str) -> None:
+    """Send a Discord notification if webhook configured."""
+    if not DISCORD_WEBHOOK_URL:
+        return
+    try:
+        requests.post(
+            DISCORD_WEBHOOK_URL, json={"content": message}, timeout=10
+        )
+    except Exception as exc:  # pragma: no cover - log only
+        logger.error("Discord notification failed: %s", exc)
+
+
+def notify(subject: str, message: str) -> None:
+    """Send an alert via all configured channels."""
+    send_email(subject, message)
+    send_discord(f"**{subject}**\n{message}")

--- a/src/fundrunner/utils/config.py
+++ b/src/fundrunner/utils/config.py
@@ -35,6 +35,7 @@ SMTP_PORT = int(os.getenv("SMTP_PORT", "587"))
 SMTP_USERNAME = os.getenv("SMTP_USERNAME", "your_email@example.com")
 SMTP_PASSWORD = os.getenv("SMTP_PASSWORD", "your_email_password")
 NOTIFICATION_EMAIL = os.getenv("NOTIFICATION_EMAIL", "recipient@example.com")
+DISCORD_WEBHOOK_URL = os.getenv("DISCORD_WEBHOOK_URL", "")
 
 # Simulation settings for paper account
 SIMULATION_MODE = os.getenv("SIMULATION_MODE", "False").lower() == "true"

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -1,0 +1,33 @@
+import fundrunner.services.notifications as notifications
+import fundrunner.alpaca.portfolio_manager as portfolio_manager
+import fundrunner.alpaca.risk_manager as risk_manager
+
+
+def test_notify_dispatch(monkeypatch):
+    emails = []
+    discord = []
+    monkeypatch.setattr(notifications, 'send_email', lambda s, b: emails.append((s, b)))
+    monkeypatch.setattr(notifications, 'send_discord', lambda m: discord.append(m))
+    notifications.notify('Subject', 'Body')
+    assert emails == [('Subject', 'Body')]
+    assert discord == ['**Subject**\nBody']
+
+
+def test_portfolio_manager_rebalance_sends_notification(monkeypatch):
+    calls = []
+    monkeypatch.setattr(portfolio_manager, 'notify', lambda s, m: calls.append((s, m)))
+    pm = portfolio_manager.PortfolioManager()
+    monkeypatch.setattr(pm.trader, 'buy', lambda *a, **k: {'id': '1'})
+    pm.rebalance_portfolio([{'symbol': 'AAPL', 'qty': 1, 'side': 'buy'}])
+    assert calls and calls[0][0] == 'Rebalance Trade Executed'
+
+
+def test_risk_manager_threshold_triggers_notification(monkeypatch):
+    calls = []
+    monkeypatch.setattr(risk_manager, 'notify', lambda s, m: calls.append((s, m)))
+    rm = risk_manager.RiskManager()
+    assert rm.check_threshold('drawdown', 5, 3) is True
+    assert calls and 'drawdown' in calls[0][1]
+    calls.clear()
+    assert rm.check_threshold('drawdown', 2, 3) is False
+    assert not calls


### PR DESCRIPTION
## Summary
- add notifications service to dispatch email and Discord alerts
- notify PortfolioManager rebalances and RiskManager threshold breaches
- document notification environment variables

## Testing
- `PYTHONPATH=src pytest`
- `flake8` *(fails: many style errors across repository)*

------
https://chatgpt.com/codex/tasks/task_e_6895b6b26b608329ba90b80c15160c56