### PR TITLE
chore: add flake8 linting configuration

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,7 @@
+[flake8]
+max-line-length = 100
+extend-ignore = E203, E266, E501, W503
+select = E9,F63,F7
+per-file-ignores =
+    __init__.py: F401
+exclude = .git,__pycache__,build,dist,.venv

--- a/README.md
+++ b/README.md
@@ -32,6 +32,14 @@ You can also install the plugin requirements manually:
 pip install -r requirements-plugins.txt
 ```
 
+## Linting
+
+Run static analysis with [`flake8`](https://flake8.pycqa.org/) to check core source files:
+
+```bash
+./scripts/lint.sh
+```
+
 ## Micro Mode
 
 Set `MICRO_MODE=true` in your `.env` file to run the bot assuming a small

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,2 +1,3 @@
 -r requirements-core.txt
 -r requirements-plugins.txt
+flake8

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+# Run flake8 linting across source directories.
+set -e
+flake8 src

--- a/src/fundrunner/alpaca/api_client.py
+++ b/src/fundrunner/alpaca/api_client.py
@@ -2,10 +2,8 @@
 """Wrapper around :mod:`alpaca_trade_api` providing convenience helpers."""
 
 import alpaca_trade_api as tradeapi
-from alpaca_trade_api.rest import TimeFrame
 from fundrunner.utils.config import API_KEY, API_SECRET, BASE_URL, DATA_FEED
 import logging
-import requests
 
 # Configure logging for this module
 logger = logging.getLogger(__name__)

--- a/src/fundrunner/plugins/portfolio_optimizer.py
+++ b/src/fundrunner/plugins/portfolio_optimizer.py
@@ -11,5 +11,5 @@ def optimize_portfolio(prices):
     mu = expected_returns.mean_historical_return(prices)
     S = risk_models.sample_cov(prices)
     ef = EfficientFrontier(mu, S)
-    weights = ef.max_sharpe()
+    _ = ef.max_sharpe()
     return ef.clean_weights()

--- a/src/fundrunner/utils/logger_config.py
+++ b/src/fundrunner/utils/logger_config.py
@@ -3,6 +3,7 @@
 import logging
 import sys
 
+
 def setup_logging(name=__name__, level=logging.DEBUG, log_file="app.log"):
     """
     Sets up and returns a logger with a console and file handler.
@@ -22,5 +23,5 @@ def setup_logging(name=__name__, level=logging.DEBUG, log_file="app.log"):
     fh.setLevel(level)
     fh.setFormatter(formatter)
     logger.addHandler(fh)
-    
+
     return logger

--- a/src/fundrunner/utils/transaction_logger.py
+++ b/src/fundrunner/utils/transaction_logger.py
@@ -12,6 +12,7 @@ import datetime
 
 TRANSACTION_LOG_FILE = os.path.join(os.path.dirname(__file__), "transactions.log")
 
+
 def log_transaction(trade_details, order):
     """Append a trade execution record to ``transactions.log``.
 
@@ -51,4 +52,4 @@ def read_transactions(limit=10):
     with open(TRANSACTION_LOG_FILE, "r") as f:
         lines = f.readlines()
     lines = lines[-limit:]
-    return [json.loads(l) for l in lines]
+    return [json.loads(line) for line in lines]

--- a/tests/test_config_portfolio_mode.py
+++ b/tests/test_config_portfolio_mode.py
@@ -1,5 +1,4 @@
 import importlib
-import os
 
 from fundrunner.utils import config as config_mod
 

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -1,6 +1,5 @@
 """Unit tests for the :mod:`dashboard` module."""
 
-import pytest
 from rich.console import Console
 
 from fundrunner.dashboards.dashboard import Dashboard

--- a/tests/test_metrics_format.py
+++ b/tests/test_metrics_format.py
@@ -6,6 +6,7 @@ from fundrunner.options.options_integration import format_primary_metric
 # Set up logging for testing
 logging.basicConfig(level=logging.DEBUG, format='%(levelname)s:%(message)s')
 
+
 def test_format_primary_metric_long():
     # Test case for long option trade metrics
     evaluation = {
@@ -22,22 +23,25 @@ def test_format_primary_metric_long():
     assert formatted.get("profit_ratio_formatted") == formatted_str, "Long metric formatting failed"
     logging.info("Long metric formatting passed with output: %s", formatted.get("profit_ratio_formatted"))
 
+
 def test_format_primary_metric_spread():
     # Test case for a spread trade metric
     evaluation = {
         "risk_reward_ratio": 1.98765,
         "adjusted_probability": 0.55,
-        "expected_return": 0.75
+        "expected_return": 0.75,
     }
-    formatted = format_primary_metric(evaluation, "risk_reward_ratio", ["adjusted_probability", "expected_return"])
+    formatted = format_primary_metric(
+        evaluation,
+        "risk_reward_ratio",
+        ["adjusted_probability", "expected_return"],
+    )
     expected_score = abs(1.98765)
     total = expected_score + abs(0.55) + abs(0.75)
     expected_weight = expected_score / total if total > 0 else 0
     formatted_str = f"{1.98765:.2f} (Score: {expected_score:.2f}, Weight: {expected_weight:.2f})"
     assert formatted.get("risk_reward_ratio_formatted") == formatted_str, "Spread metric formatting failed"
-    logging.info("Spread metric formatting passed with output: %s", formatted.get("risk_reward_ratio_formatted"))
-
-if __name__ == "__main__":
-    test_format_primary_metric_long()
-    test_format_primary_metric_spread()
-    logging.info("All metric formatting tests passed.")
+    logging.info(
+        "Spread metric formatting passed with output: %s",
+        formatted.get("risk_reward_ratio_formatted"),
+    )

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -3,6 +3,8 @@
 
 import pytest
 
+import pytest
+
 pytest.importorskip("pypfopt")
 pytest.importorskip("mplfinance")
 pytest.importorskip("transformers")
@@ -12,7 +14,6 @@ pytest.importorskip("torch")
 # 1. PyPortfolioOpt Plugin (Risk Management / Allocation)
 # ----------------------------
 
-# requirements.txt: PyPortfolioOpt
 from pypfopt import EfficientFrontier, risk_models, expected_returns
 
 
@@ -21,7 +22,7 @@ def optimize_portfolio(prices_df):
     mu = expected_returns.mean_historical_return(prices_df)
     S = risk_models.sample_cov(prices_df)
     ef = EfficientFrontier(mu, S)
-    weights = ef.max_sharpe()
+    _ = ef.max_sharpe()
     cleaned = ef.clean_weights()
     return cleaned
 
@@ -36,7 +37,6 @@ def optimize_portfolio(prices_df):
 
 # requirements.txt: mplfinance
 import mplfinance as mpf
-import pandas as pd
 
 
 def plot_trades(df, trades=None, title="Backtest Result"):
@@ -61,7 +61,6 @@ def plot_trades(df, trades=None, title="Backtest Result"):
 try:
     from transformers import AutoTokenizer, AutoModelForSequenceClassification
     import torch
-    import numpy as np
 
     # Load once at startup
     tokenizer = AutoTokenizer.from_pretrained("yiyanghkust/finbert-sentiment")

--- a/tests/test_summary_update.py
+++ b/tests/test_summary_update.py
@@ -1,6 +1,4 @@
 import asyncio
-import asyncio
-
 from fundrunner.alpaca.trading_bot import TradingBot
 from fundrunner.dashboards.textual_dashboard import DashboardApp
 

--- a/tests/test_textual_dashboard.py
+++ b/tests/test_textual_dashboard.py
@@ -1,5 +1,4 @@
 import asyncio
-import pytest
 
 from fundrunner.dashboards.textual_dashboard import DashboardApp
 
@@ -12,7 +11,7 @@ def test_dashboard_app_populates():
     app = DashboardApp(eval_q, trade_q, port_q, calc_queue=calc_q)
 
     async def _run():
-        async with app.run_test() as pilot:
+        async with app.run_test():
             await eval_q.put(("AAPL", "100", "0.5", "0.1", "Pending"))
             await trade_q.put(("AAPL", "100", "95", "110", "0.1", "OPEN"))
             await port_q.put(("AAPL", "10", "99", "100", "1.0"))

--- a/tests/test_trading_bot.py
+++ b/tests/test_trading_bot.py
@@ -1,7 +1,6 @@
 """Tests for :mod:`fundrunner.alpaca.trading_bot`."""
 
 import asyncio
-from unittest import mock
 
 from fundrunner.alpaca.trading_bot import TradingBot
 

--- a/tests/test_transaction_logger.py
+++ b/tests/test_transaction_logger.py
@@ -1,6 +1,6 @@
 import os
 import tempfile
-import json
+
 from fundrunner.utils import transaction_logger
 
 

--- a/tests/test_watchlist_view.py
+++ b/tests/test_watchlist_view.py
@@ -1,5 +1,5 @@
 import types
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch
 
 from fundrunner.utils import watchlist_view
 

--- a/tests/test_yield_farming.py
+++ b/tests/test_yield_farming.py
@@ -1,4 +1,3 @@
-import pytest
 from datetime import datetime
 
 from fundrunner.alpaca.yield_farming import YieldFarmer


### PR DESCRIPTION
## Summary
- add project-wide flake8 config and lint helper script
- document lint workflow and add flake8 to dev requirements
- clean up unused imports and formatting across source and test files

## Testing
- `./scripts/lint.sh`
- `pytest` *(fails: tests require additional dependencies and configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68a683e360348329bb757c0b2e4b09f5