### PR TITLE
feat(yield): add interactive yield farming mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,11 @@ python plugin_tools_menu.py
 
 This menu demonstrates plotting, portfolio optimization and sentiment analysis without launching the full bot.
 
+## Yield Farming Mode
+
+Select option `9` in the main CLI menu to build simple stock lending or
+dividend portfolios from available cash.
+
 ## Notifications
 
 FundRunner can alert on trades or risk events via email and Discord. Configure

--- a/tests/test_cli_menu.py
+++ b/tests/test_cli_menu.py
@@ -14,11 +14,11 @@ def test_launch_watchlist_view_calls_main():
 
 def test_run_menu_triggers_watchlist_view():
     cli = CLI()
-    with patch.object(cli, "launch_watchlist_view") as launch_mock, patch(
-        "fundrunner.main.Prompt.ask", side_effect=["8", "", "0", ""]
+    with patch.object(cli, "manage_watchlist_menu") as manage_mock, patch(
+        "fundrunner.main.Prompt.ask", side_effect=["", "5", "", "0", ""]
     ):
         try:
             cli.run()
         except SystemExit:
             pass
-        launch_mock.assert_called_once()
+        manage_mock.assert_called_once()

--- a/tests/test_yield_farming.py
+++ b/tests/test_yield_farming.py
@@ -1,5 +1,7 @@
 from datetime import datetime
 
+import pytest
+
 from fundrunner.alpaca.yield_farming import YieldFarmer
 
 
@@ -39,3 +41,15 @@ def test_build_dividend_portfolio_active(monkeypatch):
         ["AAA", "BBB"], allocation_percent=0.5, active=True
     )
     assert portfolio[0]["symbol"] == "BBB"
+
+
+def test_invalid_lending_params():
+    farmer = YieldFarmer(client=DummyClient())
+    with pytest.raises(ValueError):
+        farmer.build_lending_portfolio(allocation_percent=1.5)
+
+
+def test_dividend_requires_symbols():
+    farmer = YieldFarmer(client=DummyClient())
+    with pytest.raises(ValueError):
+        farmer.build_dividend_portfolio([], allocation_percent=0.5)


### PR DESCRIPTION
## Summary
- harden YieldFarmer portfolio builders with input validation and safer price handling
- add interactive yield farming mode to CLI and document option 9
- cover new logic with unit tests

## Testing
- `./scripts/lint.sh`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ad2878dc0483298a9212f7c4a561c6