### PR TITLE
Add roadmap and centralize lending rate fetching

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,10 @@ project/
 └── tests/
 ```
 
+## Development Roadmap
+
+See [ROADMAP.md](./ROADMAP.md) for the current yield farming development pipeline.
+
 ## Documentation
 
 Research and design documents are consolidated under `docs/PortfolioManager`.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,68 @@
+# Yield Farming Development Roadmap
+
+## Phase 1 – Stabilize Current Functionality
+
+### Audit Lending Rate Handling
+- Centralize rate fetching logic in services (e.g. `services/lending_rates.py`).
+- Improve fallback stub data (include realistic spreads, variability).
+- Add Alpaca API schema validation + error handling.
+
+### Config & CLI Enhancements
+- Expose more strategy parameters via `.env` and CLI (e.g. rebalance frequency, min allocation).
+- Validate inputs (e.g. reject allocations > 100%).
+
+### Logging & Notifications
+- Extend `notifications.py` to log yield farming results (daily yields, failed API calls).
+- Send portfolio rebalance alerts.
+
+## Phase 2 – Data & Strategy Improvements
+
+### Real Lending Rate Integrations
+- Check Alpaca’s evolving stock-lending API.
+- Add fallback sources (e.g. IBKR securities lending, Yahoo dividend yields).
+
+### Yield Estimation Engine
+- Combine lending + dividend yield.
+- Support projected annualized return calculations.
+
+### Backtesting Module
+- Extend `backtester.py` to simulate yield farming over historical dividend + rate data.
+- Plot PnL curves with `matplotlib` (hook into `dashboards/`).
+
+## Phase 3 – Portfolio Management
+
+### Position Sizing & Risk Controls
+- Auto-adjust allocations when API returns fewer than `top_n`.
+- Add diversification guardrails (e.g. sector cap, max % per ticker).
+
+### Execution Layer
+- Reuse `trading_daemon.py` but with a "lending strategy mode."
+- Add dry-run mode for paper-trading.
+
+### Rebalancing
+- Background service (in `background_trader.py`) that checks rates periodically, triggers rebalance.
+
+## Phase 4 – Monitoring & UX
+
+### CLI Dashboard
+- Show current portfolio yield, allocation breakdown, next rebalance time.
+
+### Web Dashboard (optional)
+- Build small FastAPI + Plotly/Dash module inside `dashboards/`.
+
+### Performance Tracking
+- Store portfolio history in SQLite (under `services/`).
+- Generate reports on realized vs projected yields.
+
+## Phase 5 – Deployment & Ops
+
+### Robust Testing
+- Unit tests for rate-fetching, portfolio allocation, rebalancing.
+- Mock Alpaca API for CI.
+
+### Background Mode
+- Tie Yield Farming into `BACKGROUND_MODE.md` workflows.
+
+### Docs
+- Expand `README.md` with Yield Farming tutorial.
+- Add diagrams of data flow (`docs/yield_farming_flow.md`).

--- a/src/fundrunner/alpaca/yield_farming.py
+++ b/src/fundrunner/alpaca/yield_farming.py
@@ -6,9 +6,7 @@ import logging
 from datetime import datetime
 from typing import Dict, List, Tuple
 
-import requests
-
-from fundrunner.utils.config import API_KEY, API_SECRET, BASE_URL
+from fundrunner.services.lending_rates import fetch_lending_rates
 from .api_client import AlpacaClient
 
 logger = logging.getLogger(__name__)
@@ -24,29 +22,9 @@ class YieldFarmer:
     # Stock Lending Helpers
     # ----------------------------
     def fetch_lending_rates(self) -> Dict[str, float]:
-        """Return stock lending rates keyed by symbol.
+        """Proxy to :func:`fundrunner.services.lending_rates.fetch_lending_rates`."""
 
-        Alpaca does not currently expose public stock lending endpoints. This
-        method attempts to call a hypothetical ``/v2/portfolio/stock_lending``
-        endpoint and falls back to stub data if the request fails.
-        """
-        endpoint = f"{BASE_URL}/v2/portfolio/stock_lending"
-        headers = {
-            "APCA-API-KEY-ID": API_KEY,
-            "APCA-API-SECRET-KEY": API_SECRET,
-        }
-        try:
-            resp = requests.get(endpoint, headers=headers, timeout=10)
-            if resp.ok:
-                data = resp.json()
-                return {
-                    item["symbol"]: float(item.get("rate", 0))
-                    for item in data.get("rates", [])
-                }
-        except Exception as exc:  # pragma: no cover - network failure
-            logger.warning("Failed to fetch lending rates: %s", exc)
-        # Fallback stub
-        return {"AAPL": 0.02, "MSFT": 0.015, "GOOGL": 0.012}
+        return fetch_lending_rates()
 
     def build_lending_portfolio(
         self, allocation_percent: float = 0.5, top_n: int = 3

--- a/src/fundrunner/services/lending_rates.py
+++ b/src/fundrunner/services/lending_rates.py
@@ -1,0 +1,56 @@
+"""Utilities for fetching stock lending rates from Alpaca with fallbacks."""
+
+from __future__ import annotations
+
+import logging
+from typing import Dict, Any
+
+import requests
+
+from fundrunner.utils.config import API_KEY, API_SECRET, BASE_URL
+
+logger = logging.getLogger(__name__)
+
+
+def fetch_lending_rates() -> Dict[str, float]:
+    """Return stock lending rates keyed by symbol.
+
+    Attempts to query Alpaca's ``/v2/portfolio/stock_lending`` endpoint and
+    validates the expected response schema.  If the request fails or the schema
+    is malformed, realistic stub data is returned instead.
+    """
+
+    endpoint = f"{BASE_URL}/v2/portfolio/stock_lending"
+    headers = {
+        "APCA-API-KEY-ID": API_KEY,
+        "APCA-API-SECRET-KEY": API_SECRET,
+    }
+    try:
+        resp = requests.get(endpoint, headers=headers, timeout=10)
+        resp.raise_for_status()
+        data: Any = resp.json()
+        if isinstance(data, dict):
+            rates = data.get("rates")
+            if isinstance(rates, list):
+                parsed: Dict[str, float] = {}
+                for item in rates:
+                    sym = item.get("symbol")
+                    rate = item.get("rate")
+                    if isinstance(sym, str) and isinstance(rate, (int, float)):
+                        parsed[sym] = float(rate)
+                if parsed:
+                    return parsed
+            logger.warning("Unexpected schema in lending rates response: %s", data)
+    except requests.RequestException as exc:  # pragma: no cover - network failure
+        logger.warning("Failed to fetch lending rates: %s", exc)
+    except ValueError as exc:  # pragma: no cover - JSON decode
+        logger.warning("Failed to parse lending rates: %s", exc)
+
+    # Fallback stub data with realistic spreads
+    return {
+        "AAPL": 0.027,
+        "MSFT": 0.022,
+        "GOOGL": 0.019,
+        "TSLA": 0.031,
+        "AMZN": 0.017,
+    }

--- a/tests/test_lending_rates_service.py
+++ b/tests/test_lending_rates_service.py
@@ -1,0 +1,41 @@
+"""Tests for the lending rates service."""
+
+from __future__ import annotations
+
+import requests
+
+from fundrunner.services.lending_rates import fetch_lending_rates
+
+
+class DummyResponse:
+    """Simple mock HTTP response object."""
+
+    def __init__(self, payload):
+        self._payload = payload
+
+    def raise_for_status(self):
+        """Pretend the HTTP status was successful."""
+
+    def json(self):
+        """Return the injected JSON payload."""
+        return self._payload
+
+
+def test_fetch_lending_rates_valid(monkeypatch):
+    """Parses a valid API response into a rates dictionary."""
+
+    payload = {"rates": [{"symbol": "AAA", "rate": 0.05}, {"symbol": "BBB", "rate": 0.04}]}
+    monkeypatch.setattr(requests, "get", lambda *a, **k: DummyResponse(payload))
+    rates = fetch_lending_rates()
+    assert rates == {"AAA": 0.05, "BBB": 0.04}
+
+
+def test_fetch_lending_rates_fallback(monkeypatch):
+    """Falls back to stub data when the request errors."""
+
+    def mock_get(*args, **kwargs):
+        raise requests.RequestException("network down")
+
+    monkeypatch.setattr(requests, "get", mock_get)
+    rates = fetch_lending_rates()
+    assert "AAPL" in rates and rates["AAPL"] > 0


### PR DESCRIPTION
## Summary
- document yield farming development roadmap and link from README
- centralize Alpaca lending rate fetching in new service with schema validation and richer fallback data
- add unit tests for lending rate service

## Testing
- `efake8` *(command not found)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68af3b5821b08329acfa18f1b50bf7bd