### PR TITLE
refactor: use LendingRateService in YieldFarmer

### DIFF
--- a/docs/api/alpaca.md
+++ b/docs/api/alpaca.md
@@ -180,8 +180,7 @@ Implements yield-focused strategies.
 
 ### Stock Lending
 
-- `fetch_lending_rates()` → return lending rates (fallback if API fails).
-- `build_lending_portfolio(allocation_percent=0.5, top_n=3)` → construct portfolio of top lending-rate stocks.
+- `build_lending_portfolio(allocation_percent=0.5, top_n=3)` → construct portfolio of top lending-rate stocks using `LendingRateService`.
 
 ### Dividend Capture
 

--- a/tests/test_yield_farming.py
+++ b/tests/test_yield_farming.py
@@ -19,7 +19,9 @@ class DummyClient:
 def test_build_lending_portfolio(monkeypatch):
     farmer = YieldFarmer(client=DummyClient())
     monkeypatch.setattr(
-        farmer, "fetch_lending_rates", lambda: {"AAA": 0.03, "BBB": 0.02}
+        farmer.lending_service,
+        "get_rates",
+        lambda symbols: {"AAA": 0.03, "BBB": 0.02},
     )
     portfolio = farmer.build_lending_portfolio(allocation_percent=0.5, top_n=2)
     assert len(portfolio) == 2


### PR DESCRIPTION
## Summary
- replace `fetch_lending_rates` with `LendingRateService` in `YieldFarmer`
- inject `LendingRateService` and remove legacy fetch helper
- update documentation and tests for new lending rate workflow

## Testing
- `scripts/lint.sh`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68af6d3123ec832982df1a7abfc2e431