### PR TITLE
feat: log lending rate events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## Unreleased
+### Added
+- Helpers for logging lending rate successes and failures, invoked by `LendingRateService` and `run_yield_farming`.

--- a/src/fundrunner/main.py
+++ b/src/fundrunner/main.py
@@ -11,6 +11,10 @@ from fundrunner.alpaca.watchlist_manager import WatchlistManager
 from fundrunner.alpaca.trading_bot import TradingBot
 from fundrunner.alpaca.yield_farming import YieldFarmer
 from fundrunner.services.lending_rates import LendingRateService
+from fundrunner.services.notifications import (
+    log_lending_rate_failure,
+    log_lending_rate_success,
+)
 from rich.console import Console
 from rich.table import Table
 from rich.panel import Panel
@@ -21,7 +25,7 @@ from fundrunner.utils.error_handling import (
     setup_global_error_handler,
     FundRunnerError,
     TradingError,
-    safe_execute
+    safe_execute,
 )
 import requests
 from fundrunner.utils.config import TRADING_DAEMON_URL
@@ -71,14 +75,17 @@ class CLI:
                 border_style="green",
             )
             self.console.print(info_panel)
-            
+
         success, result = safe_execute(_view_account)
         if not success:
-            error_msg = format_user_error(result, "Failed to retrieve account information")
+            error_msg = format_user_error(
+                result, "Failed to retrieve account information"
+            )
             self.console.print(f"[red]{error_msg}[/red]")
 
     def show_portfolio_status(self):
         """Render the portfolio dashboard with position details and overall profit/loss."""
+
         def _show_portfolio():
             account = self.portfolio_manager.view_account()
             positions = self.portfolio_manager.view_positions()
@@ -122,7 +129,7 @@ class CLI:
             )
             self.console.print(pl_panel)
             return {"account": account, "positions": positions}
-            
+
         success, result = safe_execute(_show_portfolio)
         if success:
             return result
@@ -298,7 +305,7 @@ class CLI:
                 order = self.trade_manager.buy(symbol, qty, order_type, time_in_force)
             elif side == "sell":
                 order = self.trade_manager.sell(symbol, qty, order_type, time_in_force)
-            
+
             if order:
                 self.console.print(f"[green]Order submitted:[/green]\n{order}")
                 trade_details = {
@@ -315,7 +322,7 @@ class CLI:
                 return True
             else:
                 raise TradingError("Order submission returned None", "SUBMIT_FAILED")
-                
+
         success, result = safe_execute(_submit_trade)
         if not success:
             error_msg = format_user_error(result, "Failed to submit trade order")
@@ -491,16 +498,18 @@ class CLI:
                 symbols_str = Prompt.ask(
                     "Symbols to consider (comma separated)", default=""
                 )
-                symbols = [s.strip().upper() for s in symbols_str.split(",") if s.strip()]
-                allocation_str = Prompt.ask(
-                    "Allocation percent (0-1)", default="0.5"
-                )
+                symbols = [
+                    s.strip().upper() for s in symbols_str.split(",") if s.strip()
+                ]
+                allocation_str = Prompt.ask("Allocation percent (0-1)", default="0.5")
                 top_n_str = Prompt.ask("Top N symbols", default="3")
 
                 try:
                     allocation = float(allocation_str)
                 except ValueError:
-                    self.console.print("[red]Allocation percent must be a number.[/red]")
+                    self.console.print(
+                        "[red]Allocation percent must be a number.[/red]"
+                    )
                     return
                 try:
                     top_n = int(top_n_str)
@@ -521,7 +530,9 @@ class CLI:
 
                 try:
                     rates = rate_service.get_rates(symbols)
+                    log_lending_rate_success(symbols, rates)
                 except FundRunnerError as exc:
+                    log_lending_rate_failure(symbols, exc)
                     self.console.print(
                         f"[red]Failed to fetch lending rates: {exc}[/red]"
                     )
@@ -544,11 +555,11 @@ class CLI:
                 symbols_str = Prompt.ask(
                     "Symbols to consider (comma separated)", default=""
                 )
-                symbols = [s.strip().upper() for s in symbols_str.split(",") if s.strip()]
+                symbols = [
+                    s.strip().upper() for s in symbols_str.split(",") if s.strip()
+                ]
                 allocation = float(
-                    Prompt.ask(
-                        "Allocation percent (0-1)", default="0.5"
-                    )
+                    Prompt.ask("Allocation percent (0-1)", default="0.5")
                 )
                 active_choice = Prompt.ask(
                     "Pick next ex-dividend stock only?", choices=["y", "n"], default="n"
@@ -755,7 +766,7 @@ def main():
     """Entry point for the FundRunner CLI application."""
     # Setup global error handling
     setup_global_error_handler()
-    
+
     cli = CLI()
     cli.run()
 

--- a/tests/test_lending_rates.py
+++ b/tests/test_lending_rates.py
@@ -18,9 +18,18 @@ def test_get_rates_falls_back_to_stub(monkeypatch):
         "fetch_live_rates",
         lambda symbols: (_ for _ in ()).throw(FundRunnerError("boom")),
     )
+    called = {}
+
+    def fake_failure(symbols, error):
+        called["failure"] = (symbols, error)
+
+    monkeypatch.setattr(
+        "fundrunner.services.lending_rates.log_lending_rate_failure", fake_failure
+    )
     symbols = ["AAPL", "MSFT"]
     rates = service.get_rates(symbols)
     assert rates == {"AAPL": 0.01, "MSFT": 0.015}
+    assert called["failure"][0] == symbols
 
 
 def test_get_rates_uses_live_when_available(monkeypatch):
@@ -28,7 +37,17 @@ def test_get_rates_uses_live_when_available(monkeypatch):
     monkeypatch.setattr(
         service, "fetch_live_rates", lambda symbols: {s: 0.5 for s in symbols}
     )
-    assert service.get_rates(["AAPL"]) == {"AAPL": 0.5}
+    called = {}
+
+    def fake_success(symbols, rates):
+        called["success"] = (symbols, rates)
+
+    monkeypatch.setattr(
+        "fundrunner.services.lending_rates.log_lending_rate_success", fake_success
+    )
+    result = service.get_rates(["AAPL"])
+    assert result == {"AAPL": 0.5}
+    assert called["success"] == (["AAPL"], {"AAPL": 0.5})
 
 
 def test_fetch_live_rates_requires_credentials(monkeypatch):


### PR DESCRIPTION
## Summary
- add notification helpers to record lending rate successes and failures
- log lending rate outcomes in `LendingRateService` and CLI `run_yield_farming`

## Testing
- `flake8`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b09a9bb4248329b295778c8302fabd