### PR TITLE
test: add lending rate and CLI option coverage

### DIFF
--- a/tests/test_cli_yield_farming.py
+++ b/tests/test_cli_yield_farming.py
@@ -1,5 +1,9 @@
-import io
+"""CLI tests covering yield farming option and error handling."""
 
+import io
+import sys
+
+import pytest
 from rich.prompt import Prompt
 from rich.console import Console
 
@@ -38,6 +42,68 @@ def test_run_yield_farming_handles_service_error(monkeypatch):
     monkeypatch.setattr(LendingRateService, "get_rates", boom)
 
     cli.run_yield_farming()
+    output = cli.console.file.getvalue()
+    assert "Failed to fetch lending rates" in output
+
+
+def test_menu_option_9_displays_rates(monkeypatch):
+    """Selecting option 9 from the main menu shows lending rates."""
+
+    cli = _setup_cli()
+    monkeypatch.setattr(CLI, "show_portfolio_status", lambda self: None)
+    monkeypatch.setattr(CLI, "print_menu", lambda self: None)
+
+    responses = iter([
+        "",  # open main menu
+        "9",
+        "lending",
+        "AAPL",
+        "0.5",
+        "1",
+        "",
+        "0",
+    ])
+    monkeypatch.setattr(Prompt, "ask", lambda *a, **k: next(responses))
+    monkeypatch.setattr(
+        LendingRateService, "get_rates", lambda self, symbols: {"AAPL": 0.02}
+    )
+    monkeypatch.setattr(sys, "exit", lambda *a, **k: (_ for _ in ()).throw(SystemExit()))
+
+    with pytest.raises(SystemExit):
+        cli.run()
+
+    output = cli.console.file.getvalue()
+    assert "AAPL" in output and "0.020" in output
+
+
+def test_menu_option_9_handles_service_error(monkeypatch):
+    """Main menu option 9 surfaces lending rate errors to the user."""
+
+    cli = _setup_cli()
+    monkeypatch.setattr(CLI, "show_portfolio_status", lambda self: None)
+    monkeypatch.setattr(CLI, "print_menu", lambda self: None)
+
+    responses = iter([
+        "",
+        "9",
+        "lending",
+        "AAPL",
+        "0.5",
+        "1",
+        "",
+        "0",
+    ])
+    monkeypatch.setattr(Prompt, "ask", lambda *a, **k: next(responses))
+
+    def boom(self, symbols):
+        raise FundRunnerError("boom")
+
+    monkeypatch.setattr(LendingRateService, "get_rates", boom)
+    monkeypatch.setattr(sys, "exit", lambda *a, **k: (_ for _ in ()).throw(SystemExit()))
+
+    with pytest.raises(SystemExit):
+        cli.run()
+
     output = cli.console.file.getvalue()
     assert "Failed to fetch lending rates" in output
 

--- a/tests/test_lending_rates.py
+++ b/tests/test_lending_rates.py
@@ -1,3 +1,5 @@
+"""Tests for the :mod:`fundrunner.services.lending_rates` module."""
+
 import pytest
 
 from fundrunner.services.lending_rates import LendingRateService
@@ -37,3 +39,34 @@ def test_fetch_live_rates_requires_credentials(monkeypatch):
     service = LendingRateService()
     with pytest.raises(FundRunnerError):
         service.fetch_live_rates(["AAPL"])
+
+
+def test_fetch_live_rates_parses_response(monkeypatch):
+    """Live rate fetch parses the API response and returns floats."""
+
+    monkeypatch.setenv("APCA_API_KEY_ID", "key")
+    monkeypatch.setenv("APCA_API_SECRET_KEY", "secret")
+    service = LendingRateService()
+
+    sample = {"rates": [{"symbol": "AAPL", "rate": 0.02}, {"symbol": "MSFT", "rate": "0.015"}]}
+
+    class MockResponse:
+        def raise_for_status(self) -> None:
+            return None
+
+        def json(self):
+            return sample
+
+    def fake_get(url, headers, params, timeout):
+        assert "stock-lending/rates" in url
+        assert headers["APCA-API-KEY-ID"] == "key"
+        assert params == {"symbols": "AAPL,MSFT"}
+        assert timeout == 10
+        return MockResponse()
+
+    monkeypatch.setattr(
+        "fundrunner.services.lending_rates.requests.get", fake_get
+    )
+
+    rates = service.fetch_live_rates(["AAPL", "MSFT"])
+    assert rates == {"AAPL": 0.02, "MSFT": 0.015}


### PR DESCRIPTION
## Summary
- add live-rate parsing test for `LendingRateService.fetch_live_rates`
- exercise CLI menu option 9 for happy-path and error scenarios

## Testing
- `flake8 tests/test_lending_rates.py tests/test_cli_yield_farming.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b09aad76088329a903977f530dc20c