### PR TITLE
docs: add lending rate API docs and CLI example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,3 +3,4 @@
 ## Unreleased
 ### Added
 - Helpers for logging lending rate successes and failures, invoked by `LendingRateService` and `run_yield_farming`.
+- Documentation for the lending rate API and Yield Farmer CLI usage example.

--- a/README.md
+++ b/README.md
@@ -81,7 +81,23 @@ This menu demonstrates plotting, portfolio optimization and sentiment analysis w
 ## Yield Farming Mode
 
 Select option `9` in the main CLI menu to build simple stock lending or
-dividend portfolios from available cash.
+dividend portfolios from available cash. Lending strategies query
+Alpaca's stock lending API via the `LendingRateService`, which falls back
+to deterministic stub rates when live requests fail. See
+[docs/api/lending_rates.md](docs/api/lending_rates.md) for endpoint
+details.
+
+Example CLI session:
+
+```bash
+python main.py
+# ...
+Select an option: 9
+Select yield strategy [lending/dividend]: lending
+Symbols to consider (comma separated): AAPL,MSFT
+Allocation percent (0-1): 0.5
+Top N symbols: 2
+```
 
 ## Notifications
 

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -6,6 +6,8 @@ This folder contains documentation for all **external APIs** and **plugin interf
 
 - [Alpaca Markets API](https://alpaca.markets/docs/)
   - Used for trading, account data, and market data feeds.
+- [Lending Rate Service](lending_rates.md)
+  - Fetches stock lending rates from Alpaca with a stub fallback.
 - [Optional Plugins]
   - Document as added.
 

--- a/docs/api/lending_rates.md
+++ b/docs/api/lending_rates.md
@@ -1,0 +1,37 @@
+# Lending Rate Service
+
+Documentation for the Alpaca stock lending rates endpoint used by
+`LendingRateService`.
+
+## Endpoint
+
+`GET /v1beta1/stock-lending/rates?symbols=AAPL,MSFT`
+
+- **Base URL:** `https://paper-api.alpaca.markets`
+- **Official Docs:** https://docs.alpaca.markets/reference/getstocklendingrates
+
+### Query Parameters
+
+| Name    | Description                                      |
+|---------|--------------------------------------------------|
+| symbols | Comma-separated list of ticker symbols to query. |
+
+### Response
+
+A successful request returns JSON containing rate information:
+
+```json
+{
+  "rates": [
+    {"symbol": "AAPL", "rate": 0.0123},
+    {"symbol": "MSFT", "rate": 0.0101}
+  ]
+}
+```
+
+## Fallback Behaviour
+
+`LendingRateService.get_rates` attempts to fetch live data. If
+credentials are missing or the request fails, deterministic stub rates
+starting at `0.01` and increasing by `0.005` per symbol are returned.
+Failures and successes are logged via the notification helpers.


### PR DESCRIPTION
## Summary
- document Alpaca stock lending endpoint and stub fallback
- link README to new lending rate service with sample yield farming session
- note addition in API index and changelog

## Testing
- `./scripts/lint.sh`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b2839173cc8329aff394107e092f97