### PR TITLE
feat(services): add SQLite portfolio database skeleton

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,4 +3,5 @@
 ## Unreleased
 ### Added
 - Helpers for logging lending rate successes and failures, invoked by `LendingRateService` and `run_yield_farming`.
+- SQLite-backed PortfolioDB service skeleton for yield history storage.
 - Documentation for the lending rate API and Yield Farmer CLI usage example.

--- a/docs/portfolio_db.md
+++ b/docs/portfolio_db.md
@@ -1,0 +1,13 @@
+# Portfolio Database Service
+
+`PortfolioDB` provides a lightweight SQLite backend for recording yield
+history. The service initialises a local database with a single
+`yield_history` table capturing the symbol, yield rate, and timestamp of
+each observation.
+
+## Integration
+
+- **LendingRateService** – after fetching rates, call
+  `record_lending_rates` to persist the snapshot.
+- **Portfolio tracking** – portfolio managers or analytics components can
+  query `get_yield_history` to analyse historical returns.

--- a/src/fundrunner/services/portfolio_db.py
+++ b/src/fundrunner/services/portfolio_db.py
@@ -1,0 +1,81 @@
+"""SQLite-backed storage for portfolio yield history.
+
+This module manages a local SQLite database used to record historical
+yield data for tracked symbols.  It is designed as a lightweight
+persistence layer for yield farming features.
+
+Integration points
+------------------
+- :class:`~fundrunner.services.lending_rates.LendingRateService` should call
+  :meth:`PortfolioDB.record_lending_rates` after fetching rates to persist
+  daily lending yields.
+- Portfolio tracking components, such as the portfolio manager, can query
+  :meth:`PortfolioDB.get_yield_history` to analyse past returns and
+  calculate performance metrics.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+from typing import Dict, List, Tuple
+
+DB_NAME = "portfolio.db"
+SCHEMA = """
+CREATE TABLE IF NOT EXISTS yield_history (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    symbol TEXT NOT NULL,
+    rate REAL NOT NULL,
+    timestamp TEXT NOT NULL
+);
+"""
+
+
+class PortfolioDB:
+    """Simple SQLite wrapper for storing yield history."""
+
+    def __init__(self, db_path: str | Path = DB_NAME) -> None:
+        """Initialise the database connection and ensure schema exists."""
+
+        self.db_path = str(db_path)
+        self.conn = sqlite3.connect(self.db_path)
+        self._init_db()
+
+    def _init_db(self) -> None:
+        """Create tables if they do not already exist."""
+
+        with self.conn:
+            self.conn.executescript(SCHEMA)
+
+    def record_lending_rates(self, rates: Dict[str, float], timestamp: str) -> None:
+        """Insert a batch of lending rates.
+
+        Args:
+            rates: Mapping of ticker symbol to lending rate.
+            timestamp: ISO 8601 timestamp representing when the rate was
+                observed.
+
+        This method is intended to be invoked by
+        :class:`~fundrunner.services.lending_rates.LendingRateService` after
+        successful rate retrieval.
+        """
+
+        with self.conn:
+            self.conn.executemany(
+                "INSERT INTO yield_history (symbol, rate, timestamp) VALUES (?, ?, ?)",
+                [(symbol, rate, timestamp) for symbol, rate in rates.items()],
+            )
+
+    def get_yield_history(self, symbol: str) -> List[Tuple[str, float]]:
+        """Return ordered list of ``(timestamp, rate)`` entries for a symbol."""
+
+        cursor = self.conn.execute(
+            "SELECT timestamp, rate FROM yield_history WHERE symbol = ? ORDER BY timestamp",
+            (symbol,),
+        )
+        return cursor.fetchall()
+
+    def close(self) -> None:
+        """Close the underlying SQLite connection."""
+
+        self.conn.close()

--- a/tests/test_portfolio_db.py
+++ b/tests/test_portfolio_db.py
@@ -1,0 +1,14 @@
+import os
+import tempfile
+
+from fundrunner.services.portfolio_db import PortfolioDB
+
+
+def test_record_and_fetch_yield_history():
+    with tempfile.TemporaryDirectory() as tmp:
+        db_path = os.path.join(tmp, "portfolio.db")
+        db = PortfolioDB(db_path)
+        db.record_lending_rates({"AAPL": 0.02, "MSFT": 0.03}, "2024-01-01T00:00:00Z")
+        history = db.get_yield_history("AAPL")
+        db.close()
+        assert history == [("2024-01-01T00:00:00Z", 0.02)]


### PR DESCRIPTION
## Summary
- add PortfolioDB service with SQLite schema to store yield history
- document integration points with LendingRateService and portfolio tracking
- cover new service with unit test

## Testing
- `scripts/lint.sh && echo lint-passed`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b7c92af1888329bf01fc502665d85c